### PR TITLE
Allowing non-inputs in the form

### DIFF
--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import { default as Button, ButtonStyle } from './button';
-import InputField from './input_field'
 
 export interface FormProps {
 	/** Primary button text */
@@ -67,14 +66,14 @@ export class Form extends React.Component<FormProps, FormState> {
 
 		return (
 			<form noValidate className="form" onSubmit={this._onSubmitHandler}>
-				{React.Children.map(children, (child: any) => InputField.isPrototypeOf(child.type) ? (
+				{React.Children.map(children, (child: any) => HTMLElement.isPrototypeOf(child.type) ? child : (
 					<div className="form__item">
 						{child && React.cloneElement(child, formValidation.validationErrors[child.props.id] && {
 							validationError: isValidationErrors && formValidation.validationErrors[child.props.id],
 							validationErrorMsg: isValidationErrors ? formValidation.validationErrors[child.props.id] : null
 						})}
 					</div>
-				) : child)}
+				))}
 
 				{primaryBtnText &&
 					<div className="form__actions">

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import { default as Button, ButtonStyle } from './button';
+import InputField from './input_field'
 
 export interface FormProps {
 	/** Primary button text */
@@ -66,14 +67,14 @@ export class Form extends React.Component<FormProps, FormState> {
 
 		return (
 			<form noValidate className="form" onSubmit={this._onSubmitHandler}>
-				{React.Children.map(children, (child: any) => {
-					return <div className="form__item">
-						{child && React.cloneElement(child, {
+				{React.Children.map(children, (child: any) => InputField.isPrototypeOf(child.type) ? (
+					<div className="form__item">
+						{child && React.cloneElement(child, formValidation.validationErrors[child.props.id] && {
 							validationError: isValidationErrors && formValidation.validationErrors[child.props.id],
 							validationErrorMsg: isValidationErrors ? formValidation.validationErrors[child.props.id] : null
 						})}
 					</div>
-				})}
+				) : child)}
 
 				{primaryBtnText &&
 					<div className="form__actions">

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import { default as Button, ButtonStyle } from './button';
+import InputField from './input_field'
 
 export interface FormProps {
 	/** Primary button text */
@@ -66,14 +67,14 @@ export class Form extends React.Component<FormProps, FormState> {
 
 		return (
 			<form noValidate className="form" onSubmit={this._onSubmitHandler}>
-				{React.Children.map(children, (child: any) => HTMLElement.isPrototypeOf(child.type) ? child : (
+				{React.Children.map(children, (child: any) => InputField.isPrototypeOf(child.type) ? (
 					<div className="form__item">
 						{child && React.cloneElement(child, formValidation.validationErrors[child.props.id] && {
 							validationError: isValidationErrors && formValidation.validationErrors[child.props.id],
 							validationErrorMsg: isValidationErrors ? formValidation.validationErrors[child.props.id] : null
 						})}
 					</div>
-				))}
+				) : child)}
 
 				{primaryBtnText &&
 					<div className="form__actions">


### PR DESCRIPTION
- This is necessary for the oAuth2 login page, for example (forgot your password link).
- Passing DOM elements as child gave the error: "React does not recognize the `validationErrorMsg` prop on a DOM element"