### PR TITLE
Fix context menu classes after converting to scss

### DIFF
--- a/src/stylesheets/_context_menu.scss
+++ b/src/stylesheets/_context_menu.scss
@@ -89,29 +89,30 @@
                     cursor: pointer;
                     padding: 1.2rem 2.4rem;
 
-                    &:last-child {}
-
-                    border-bottom: none;
-
-                    &:hover {}
-
-                    background-color: $context-menu-color-hover;
-                    transition: background-color 0.2s ease-out;
-
-                    &.disabled {}
-
-                    color: $color-text-lighter;
-                    transition: color 0.2s ease-out;
-                    cursor: default;
+                    &:last-child {
+                        border-bottom: none;
+                    }
 
                     &:hover {
-                        background-color: $context-menu-color-background;
+                        background-color: $context-menu-color-hover;
                         transition: background-color 0.2s ease-out;
                     }
 
-                    .additional-info {}
+                    &.disabled {
+                        color: $color-text-lighter;
+                        transition: color 0.2s ease-out;
+                        cursor: default;
 
-                    color: $color-text-lighter;
+                        &:hover {
+                            background-color: $context-menu-color-background;
+                            transition: background-color 0.2s ease-out;
+                        }
+                    }
+
+                    .additional-info {
+                        color: $color-text-lighter;
+                    }
+
                 }
             }
         }


### PR DESCRIPTION
The convert script made a couple of errors in `_context_menu.scss`. These look to be the only cases.