### PR TITLE
Adding 'accept' to FileUpload, giving opacity=0 instead of display=none

### DIFF
--- a/src/components/__tests__/__snapshots__/file_upload.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/file_upload.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`The FileUpload component should render 1`] = `
   onClick={[Function]}
 >
   <input
+    accept={null}
     id="testFileUpload"
     name="testFileUpload"
     onChange={[Function]}

--- a/src/components/file_upload.tsx
+++ b/src/components/file_upload.tsx
@@ -15,6 +15,8 @@ export interface FileUploadProps {
     uploading?: boolean;
     /** Placeholder text */
     placeholder?: string;
+    /** What kinds of file extensions should be accepted client-side **/
+    accept?: string[];
 }
 
 export interface FileUploadState {
@@ -42,7 +44,7 @@ export class FileUpload extends React.Component<FileUploadProps, FileUploadState
     }
 
     render(): JSX.Element {
-        const { id, disabled, placeholder, uploading } = this.props;
+        const { id, disabled, placeholder, uploading, accept } = this.props;
         const { selectedFileName } = this.state;
 
         const classes = classNames('file-upload', { disabled });
@@ -56,6 +58,7 @@ export class FileUpload extends React.Component<FileUploadProps, FileUploadState
                 onChange={this._onChangeHandler}
                 disabled={disabled}
                 placeholder={placeholder}
+                accept={accept ? accept.join(",") : null}
             />
             <div className="layout layout--gutter-sm">
                 <div className="layout__item u-fill file-upload__input-container">

--- a/src/components/input_fields/file_upload_field.tsx
+++ b/src/components/input_fields/file_upload_field.tsx
@@ -18,6 +18,8 @@ export interface FileUploadFieldProps extends InputFieldProps {
     placeholder?: string;
     /** Whether the file is being uploaded (so the upload button is disabled) **/
     uploading?: boolean;
+    /** What kinds of file extensions should be accepted client-side **/
+    accept?: string[];
 }
 
 /**
@@ -62,7 +64,7 @@ class FileUploadField extends React.Component<FileUploadFieldProps, FileUploadFi
     }
 
     render() {
-        const {placeholder, uploading, children, ...wrapperProps} = this.props;
+        const {placeholder, uploading, children, accept, ...wrapperProps} = this.props;
         const {id, staticField} = wrapperProps;
         const {touched} = this.state;
         return <InputFieldWrapper inputChildren={children} touched={touched} {...wrapperProps}>
@@ -72,6 +74,7 @@ class FileUploadField extends React.Component<FileUploadFieldProps, FileUploadFi
                 disabled={staticField}
                 uploading={uploading}
                 placeholder={placeholder}
+                accept={accept}
             />
         </InputFieldWrapper>;
     }

--- a/src/stories/form.stories.tsx
+++ b/src/stories/form.stories.tsx
@@ -325,6 +325,7 @@ stories.add('Upload file field', withState({ value: null })
                     infoLinkURL={text('Info link URL', '')}
                     infoText={text('Info text', '')}
                     preLabelElement={text('Pre label element', '')}
+                    accept={text('Accept file types', '.pdf,.zip').split(",")}
                 />
             </div>
         )

--- a/src/stylesheets/_forms.scss
+++ b/src/stylesheets/_forms.scss
@@ -299,6 +299,7 @@
     input {
         position: absolute;
         opacity: 0;
+        left: -9999px;
     }
 
     .file-upload__input-container {

--- a/src/stylesheets/_forms.scss
+++ b/src/stylesheets/_forms.scss
@@ -297,7 +297,8 @@
 
 .file-upload {
     input {
-        display: none;
+        position: absolute;
+        opacity: 0;
     }
 
     .file-upload__input-container {


### PR DESCRIPTION
This PR makes the 'accept' prop available for the file input field.

Also it changes the styling: With opacity=0 and position=absolute the file input field should not be displayed, but is still be available by using the tab character and clicking on the labels.