### PR TITLE
Make select list accessible

### DIFF
--- a/src/components/__tests__/__snapshots__/select_list.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/select_list.test.tsx.snap
@@ -4,7 +4,8 @@ exports[`The SelectList component should render 1`] = `
 <div
   className="drop-down-menu"
   onBlur={[Function]}
-  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
   tabIndex={1}
 >
   <div
@@ -36,7 +37,6 @@ exports[`The SelectList component should render 1`] = `
   </div>
   <div
     className="container"
-    onClick={[Function]}
   >
     <div
       className="menu"
@@ -53,24 +53,27 @@ exports[`The SelectList component should render 1`] = `
         <ul>
           <SelectListItem
             active={true}
+            focused={false}
             key="0"
             label="Option 1"
-            onChangeHandler={[MockFunction]}
+            onChangeHandler={[Function]}
             value={1}
           />
           <SelectListItem
             active={false}
             disabled={true}
+            focused={false}
             key="1"
             label="Option 2"
-            onChangeHandler={[MockFunction]}
+            onChangeHandler={[Function]}
             value={2}
           />
           <SelectListItem
             active={false}
+            focused={false}
             key="2"
             label="Option 3"
-            onChangeHandler={[MockFunction]}
+            onChangeHandler={[Function]}
             value={3}
           />
         </ul>

--- a/src/components/__tests__/select_list.test.tsx
+++ b/src/components/__tests__/select_list.test.tsx
@@ -36,18 +36,14 @@ describe('The SelectList component', () => {
         expect(wrapper.find('.visible')).toHaveLength(1);
     });
 
+    it('should show menu when focused', () => {
+        wrapper.simulate('focus');
+        expect(wrapper.find('.visible')).toHaveLength(1);
+    });
+
     it('should not render a label when value is null', () => {
         wrapper.setProps({ value: null });
         expect(wrapper.find('.text').text()).toBe('');
-    });
-
-    it('should hide menu when the label is clicked', () => {
-        // first open the menu
-        wrapper.find('.label').simulate('click', mockClickEvent);
-        expect(wrapper.find('.visible')).toHaveLength(1);
-        // then close it
-        wrapper.find('.label').simulate('click', mockClickEvent);
-        expect(wrapper.find('.visible').exists()).toBe(false);
     });
 
     it('should hide menu on blur', () => {
@@ -59,18 +55,31 @@ describe('The SelectList component', () => {
         expect(wrapper.find('.visible').exists()).toBe(false);
     });
 
-    it('should hide menu on menu click', () => {
+    it('should hide menu when item is clicked', () => {
         // first open the menu
         wrapper.find('.label').simulate('click', mockClickEvent);
         expect(wrapper.find('.visible')).toHaveLength(1);
-        // then close it
-        wrapper.find('.container').simulate('click', mockClickEvent);
+        // select an item
+        wrapper.instance()._onClickHandler('1', false);
         expect(wrapper.find('.visible').exists()).toBe(false);
     });
 
-    it('should not propagate click', () => {
-        wrapper.simulate('click', mockClickEvent);
-        expect(mockClickEvent.stopPropagation).toBeCalled();
+    it('should select item with the keyboard', () => {
+        // increase selected item
+        wrapper.instance()._updateFocusedIndex(+1);
+        expect(wrapper.state('focusedIndex')).toBe(0);
+        wrapper.instance()._updateFocusedIndex(+1);
+        expect(wrapper.state('focusedIndex')).toBe(1);
+        wrapper.instance()._updateFocusedIndex(+1);
+        expect(wrapper.state('focusedIndex')).toBe(2);
+        // index should be circular, so after 2 it goes back to 0
+        wrapper.instance()._updateFocusedIndex(+1);
+        expect(wrapper.state('focusedIndex')).toBe(0);
+        // decrease selected item, again should be circular
+        wrapper.instance()._updateFocusedIndex(-1);
+        expect(wrapper.state('focusedIndex')).toBe(2);
+        wrapper.instance()._updateFocusedIndex(-1);
+        expect(wrapper.state('focusedIndex')).toBe(1);
     });
 
 });

--- a/src/components/select_list.tsx
+++ b/src/components/select_list.tsx
@@ -57,6 +57,14 @@ export class SelectList extends React.Component<SelectListProps, SelectListState
         return option ? option.label : null;
     }
 
+    /**
+     * Handle clicking on a menu item. If the the clicked option is not disabled, 
+     * call the onChangeHandler from the props, 
+     * clear the stored focused index,
+     * and close the menu.
+     * @param value - the value of the selected meu item
+     * @param disabled - whether the selected item is disabled
+     */
     private _onClickHandler(value, disabled) {
         const { onChangeHandler } = this.props;
         
@@ -67,18 +75,23 @@ export class SelectList extends React.Component<SelectListProps, SelectListState
         }
     }
 
+    /**
+     * Updates the focusedIndex and validates it
+     * @param changeByValue - value to adjust the focusedIndex by
+     */
     private _updateFocusedIndex(changeByValue: number): void {
         const { options } = this.props;
         const { focusedIndex } = this.state;
 
-        this._setShowMenu(true);
-
+        // if the focusedIndex has not been set, set it to 0, otherwise adjust it by the value of the changeByValue
         let newIndex = focusedIndex !== null ? focusedIndex + changeByValue : 0;
 
+        // if the user presses down on the last item, go to the first
         if (newIndex > options.length - 1) {
             newIndex = 0;
         }
 
+        // if the user presses up on the first item, go the last
         if (newIndex < 0) {
             newIndex = options.length - 1;
         }
@@ -92,9 +105,11 @@ export class SelectList extends React.Component<SelectListProps, SelectListState
 
         switch (e.key) {
             case 'ArrowDown':
+                this._setShowMenu(true);
                 this._updateFocusedIndex(1);
                 break;
             case 'ArrowUp':
+                this._setShowMenu(true);
                 this._updateFocusedIndex(-1);
                 break;
             case 'Enter':

--- a/src/components/select_list.tsx
+++ b/src/components/select_list.tsx
@@ -28,12 +28,21 @@ export interface SelectOption {
 
 export interface SelectListState {
     showMenu: boolean;
+    focusedIndex: number;
 }
 
 export class SelectList extends React.Component<SelectListProps, SelectListState> {
 
     state = {
-        showMenu: false
+        showMenu: false,
+        focusedIndex: null
+    }
+
+    constructor(props) {
+        super(props);
+
+        this._onKeyPressed = this._onKeyPressed.bind(this);
+        this._onClickHandler = this._onClickHandler.bind(this);
     }
 
     private _setShowMenu(showMenu: boolean): void {
@@ -48,21 +57,70 @@ export class SelectList extends React.Component<SelectListProps, SelectListState
         return option ? option.label : null;
     }
 
-    private _stopPropagation(e: React.MouseEvent<HTMLDivElement>) {
-        e.stopPropagation()
+    private _onClickHandler(value, disabled) {
+        const { onChangeHandler } = this.props;
+        
+        if (!disabled && value) {
+            onChangeHandler(value);
+            this.setState({ focusedIndex: null });
+            this._setShowMenu(false);
+        }
+    }
+
+    private _updateFocusedIndex(changeByValue: number): void {
+        const { options } = this.props;
+        const { focusedIndex } = this.state;
+
+        this._setShowMenu(true);
+
+        let newIndex = focusedIndex !== null ? focusedIndex + changeByValue : 0;
+
+        if (newIndex > options.length - 1) {
+            newIndex = 0;
+        }
+
+        if (newIndex < 0) {
+            newIndex = options.length - 1;
+        }
+
+        this.setState({ focusedIndex: newIndex });
+    }
+
+    private _onKeyPressed(e) {
+        const { options } = this.props;
+        const { focusedIndex } = this.state;
+
+        switch (e.key) {
+            case 'ArrowDown':
+                this._updateFocusedIndex(1);
+                break;
+            case 'ArrowUp':
+                this._updateFocusedIndex(-1);
+                break;
+            case 'Enter':
+                const focusedItem = options[focusedIndex];
+                if(focusedItem) {
+                    this._onClickHandler(focusedItem.value, focusedItem.disabled)
+                }
+                break;
+        }
     }
 
     render(): JSX.Element {
-        const { id, error, options, value, onChangeHandler } = this.props;
-        const { showMenu } = this.state;
+        const { id, error, options, value } = this.props;
+        const { showMenu, focusedIndex } = this.state;
 
         const dropDownMenuClasses = classNames('drop-down-menu', { 'visible': showMenu });
         const labelClasses = classNames('label', { 'active': showMenu, error });
 
-        return <div id={id} className={dropDownMenuClasses} tabIndex={1}
-            onClick={this._stopPropagation} onBlur={() => this._setShowMenu(false)}>
+        return <div id={id} className={dropDownMenuClasses}
+            tabIndex={1}
+            onFocus={() => this._setShowMenu(true)}
+            onBlur={() => this._setShowMenu(false)}
+            onKeyDown={this._onKeyPressed}
+        >
 
-            <div className={labelClasses} onClick={() => this._setShowMenu(!showMenu)} >
+            <div className={labelClasses} onClick={() => this._setShowMenu(true)} >
                 <div className="layout layout--align-middle layout--gutter-none">
                     <div className="layout__item u-fit">
                         <div className="text">{this._getActiveOptionLabel()}</div>
@@ -73,16 +131,18 @@ export class SelectList extends React.Component<SelectListProps, SelectListState
                 </div>
             </div>
 
-            <div className="container" onClick={() => this._setShowMenu(false)}>
+            <div className="container">
                 <div ref="menu" className="menu">
                     <UnmountClosed isOpened={showMenu} springConfig={{ stiffness: 370, damping: 35 }}>
                         <ul>
                             {options.map((option, index) => {
-                                return <SelectListItem key={index} onChangeHandler={onChangeHandler}
+                                return <SelectListItem key={index}
+                                    onChangeHandler={this._onClickHandler}
                                     label={option.label}
                                     value={option.value}
                                     active={value === option.value}
-                                    disabled={option.disabled} />
+                                    disabled={option.disabled}
+                                    focused={focusedIndex === index && !option.disabled} />
                             })}
                         </ul>
                     </UnmountClosed>

--- a/src/components/select_list_item.tsx
+++ b/src/components/select_list_item.tsx
@@ -7,26 +7,28 @@ export interface SelectListItemProps {
     /** Disables the menu item when true */
     disabled?: boolean;
     /** Called when the menu item is clicked */
-    onChangeHandler: (value: string | number) => void;
+    onChangeHandler: (value: string | number, disabled: boolean) => void;
     /** The label for the menu item */
     label: string;
     /** The value of the menu item */
     value: string | number;
+    /** Whether the item is focused */
+    focused: boolean;
 }
 
 export const SelectListItem: React.StatelessComponent<SelectListItemProps> =
-    ({ active, disabled, onChangeHandler, label, value }) => {
+    ({ active, disabled, onChangeHandler, label, value, focused }) => {
 
         const _onClickHandler = (e: React.MouseEvent<HTMLLIElement>) => {
             if (disabled) {
                 e.stopPropagation();
             }
             else {
-                onChangeHandler(value);
+                onChangeHandler(value, disabled);
             }
         }
 
-        return <li className={classNames({ disabled, active })} onClick={_onClickHandler}>
+        return <li className={classNames({ disabled, active, focused })} onClick={_onClickHandler}>
             {label}
         </li>
 

--- a/src/stylesheets/_context_menu.scss
+++ b/src/stylesheets/_context_menu.scss
@@ -93,7 +93,7 @@
                         border-bottom: none;
                     }
 
-                    &:hover {
+                    &:hover, &.focused {
                         background-color: $context-menu-color-hover;
                         transition: background-color 0.2s ease-out;
                     }


### PR DESCRIPTION
This PR adds accessibility to the select list component. It should now be possible to use the component with only the keyboard. This means you can now tab to it, then use the up and down arrows to focus an option, and enter to select an option.