### PR TITLE
Hide account management URL button if no URL is passed

### DIFF
--- a/src/components/user_account_menu.tsx
+++ b/src/components/user_account_menu.tsx
@@ -19,7 +19,7 @@ export interface UserAccountMenuProps {
     /** Called when the sign out button is clicked */
     onSignOutClickHandler: () => void;
     /** URL to the account management page */
-    manageAccountURL: string;
+    manageAccountURL?: string;
     /** The display name of the user. */
     displayName: string
     /** An URL for the user profile image. */
@@ -117,10 +117,10 @@ export class UserAccountMenu extends React.Component<UserAccountMenuProps, UserA
                                         </div>
 
                                         <div className="account-section__buttons">
-                                            <Button style="secondary" type="link" linkURL={manageAccountURL} linkToNewTab>
+                                            {manageAccountURL && <Button style="secondary" type="link" linkURL={manageAccountURL} linkToNewTab>
                                                 {I18n.translate("User account menu button", "Manage account")}
                                                 <LinkIcon />
-                                            </Button>
+                                            </Button>}
 
                                             <Button style="secondary" onClickHandler={() => { this._setShowMenu(false); onSignOutClickHandler() }}>
                                                 {I18n.translate("User account menu button", "Sign out")}

--- a/src/stories/menu.stories.tsx
+++ b/src/stories/menu.stories.tsx
@@ -62,11 +62,11 @@ stories.add('User account menu', withInfo(
 )(() =>
     <UserAccountMenu
         onSignOutClickHandler={action('clicked')}
-        manageAccountURL="https://account-staging.ultimaker.com"
+        manageAccountURL={text('Account Management URL', 'https://account.ultimaker.com')}
         displayName="Test User"
         triggerWidth={text('Trigger width', null)}
         triggerHeight={text('Trigger height', null)}
         signedOut={boolean('Sign out', false)}
         onSignInClickHandler={action('clicked')}
-    ></UserAccountMenu>
+    />
 ));


### PR DESCRIPTION
This allows the manage account button in the account dropdown to be optional. I want to use this in the account.ultimaker.com page where you're already on the management portal and just want to show the profile picture and sign out button in the top right.