### PR TITLE
Adding a timeout to the loading page

### DIFF
--- a/src/components/__tests__/__snapshots__/loading_page.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/loading_page.test.tsx.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`The LoadingPage component should render 1`] = `
-<div
-  className="loading-page"
->
-  <Spinner />
-</div>
-`;

--- a/src/components/__tests__/loading_page.test.tsx
+++ b/src/components/__tests__/loading_page.test.tsx
@@ -4,16 +4,24 @@ import { shallow } from 'enzyme';
 
 // component
 import LoadingPage from '../loading_page';
+import Spinner from '../spinner';
 
 describe('The LoadingPage component', () => {
     let wrapper;
 
     beforeEach(() => {
+        jest.useFakeTimers();
         wrapper = shallow(<LoadingPage />);
     });
 
-    it('should render', () => {
-        expect(wrapper).toMatchSnapshot();
+    afterEach(() => {
+        jest.useRealTimers();
+    })
+
+    it('should spinner after timeout', () => {
+        expect(wrapper.find(Spinner)).toHaveLength(0);
+        jest.runOnlyPendingTimers();
+        expect(wrapper.find(Spinner)).toHaveLength(1);
     });
 
 });

--- a/src/components/loading_page.tsx
+++ b/src/components/loading_page.tsx
@@ -2,13 +2,70 @@ import * as React from 'react';
 
 import Spinner from './spinner';
 
-export const LoadingPage: React.StatelessComponent = (): JSX.Element => {
+/**
+ * The props of this component.
+ */
+export interface LoadingPageProps {
+    /**
+     * The page will only show the spinner if it is rendered for this amount of milliseconds.
+     * This way we can avoid flashing the spinner in fast pages, and only show it when it takes long.
+     **/
+    timeoutMs?: number,
+}
 
-    return <div className="loading-page">
-        <Spinner />
-    </div>
+/**
+ * The state of this component.
+ */
+export interface LoadingPageState {
+    /**
+     * When timed out the spinner is shown.
+     **/
+    isTimedOut: boolean,
+}
+
+/**
+ * A page with a loading spinner.
+ */
+export default class LoadingPage extends React.Component<LoadingPageProps, LoadingPageState> {
+    /** The timer that will time out the page and show the spinner **/
+    private _timeout: any = null;
+
+    state = {
+        isTimedOut: false,
+    }
+
+    static defaultProps = {
+        timeoutMs: 500,
+    }
+
+    constructor(props: LoadingPageProps) {
+        super(props);
+        this._onTimeout = this._onTimeout.bind(this);
+    }
+
+    componentDidMount(): void {
+        const { timeoutMs } = this.props;
+        this._timeout = setTimeout(this._onTimeout, timeoutMs);
+    }
+
+    componentWillUnmount(): void {
+        if (this._timeout) {
+            clearTimeout(this._timeout);
+            this._timeout = null;
+        }
+    }
+
+    private _onTimeout() {
+        this._timeout = null;
+        this.setState({ isTimedOut: true })
+    }
+
+    render(): JSX.Element {
+        const { isTimedOut } = this.state;
+        return (
+            <div className="loading-page">
+                {isTimedOut && <Spinner/>}
+            </div>
+        );
+    }
 };
-
-LoadingPage.displayName = "LoadingPage";
-
-export default LoadingPage;

--- a/src/stories/loading.stories.tsx
+++ b/src/stories/loading.stories.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text } from '@storybook/addon-knobs/react';
+import { withKnobs, text, number } from '@storybook/addon-knobs/react';
 import styles from "@sambego/storybook-styles";
 import { withInfo } from '@storybook/addon-info';
 
 import Loading from '../components/loading';
 import LoadingPage from '../components/loading_page';
-import Spinner from '../components/spinner';
 
 const stories = storiesOf('Loading', module);
 
@@ -26,6 +25,8 @@ stories.add('Loading text', withInfo(
 
 stories.add('Loading page', withInfo(
     'Full page loading spinner. To be used when the application is loading.'
-)(() =>
-    <LoadingPage />
-));
+)(() => {
+    // pass the timeout as key so that it gets remounted when it changes.
+    const timeout = number('Timeout to show spinner', 500);
+    return <LoadingPage timeoutMs={timeout} key={timeout} />;
+}));


### PR DESCRIPTION
By default, this PR will change the loading page behavior so that it only gets rendered after 0,5 second.

This way we can avoid flashing the spinner in fast pages, and only show it when it takes long.