### PR TITLE
change $color-transparent to a white base

### DIFF
--- a/src/stylesheets/_variables.scss
+++ b/src/stylesheets/_variables.scss
@@ -12,7 +12,7 @@ $color-grey-light: #dcdcdc !default;
 $color-grey-lighter: #e6e6e6 !default;
 $color-grey-lightest: #f3f3f3 !default;
 $color-white: #ffffff !default;
-$color-transparent: rgba(0, 0, 0, 0) !default;
+$color-transparent: rgba(255, 255, 255, 0) !default;
 $color-transparent-grey-lighter: rgba(0, 0, 0, 0.03) !default;
 $color-transparent-grey-light: rgba(0, 0, 0, 0.06) !default;
 $color-transparent-grey-mid: rgba(0, 0, 0, 0.09) !default;


### PR DESCRIPTION
This is to fix a bug in safari when using linear-gradient with $color-transparent