### PR TITLE
Rename style to appearance

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
         "jsx-closing-tag-location": 0,
         "react/jsx-indent": ["error", 4],
         "react/jsx-indent-props": ["error", 4],
-        "react/style-prop-object": 0,
         "react/no-array-index-key": 0
     },
     settings: {

--- a/src/components/__tests__/__snapshots__/button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`The Button component renders a anchor when prop \`type\` is link and an external link is given 1`] = `
 <a
-  className="btn btn--primary btn--rectangle "
+  className="btn btn--undefined btn--rectangle "
   href="https://ultimaker.com/"
   id="testButton"
   rel="noopener noreferrer"
@@ -17,7 +17,7 @@ exports[`The Button component renders a anchor when prop \`type\` is link and an
 
 exports[`The Button component renders a link when prop \`type\` is link and an internal link is given 1`] = `
 <Link
-  className="btn btn--primary btn--rectangle "
+  className="btn btn--undefined btn--rectangle "
   id="testButton"
   replace={false}
   to="/print_jobs"
@@ -32,7 +32,7 @@ exports[`The Button component renders a link when prop \`type\` is link and an i
 
 exports[`The Button component should render 1`] = `
 <button
-  className="btn btn--primary btn--rectangle "
+  className="btn btn--undefined btn--rectangle "
   id="testButton"
   onClick={[Function]}
   type="button"

--- a/src/components/__tests__/__snapshots__/close_button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/close_button.test.tsx.snap
@@ -2,11 +2,12 @@
 
 exports[`The CloseButton component should render 1`] = `
 <Button
+  appearance="quiet"
   className="close-button"
   linkToNewTab={false}
   onClickHandler={[Function]}
   shape="circle"
-  style="quiet"
+  style="primary"
   type="button"
 >
   <Icon(CrossIcon) />

--- a/src/components/__tests__/__snapshots__/drop_down_menu_base.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/drop_down_menu_base.test.tsx.snap
@@ -6,11 +6,12 @@ exports[`The DropDownMenuBase component should render 1`] = `
   onClick={[Function]}
 >
   <Button
+    appearance="no-style"
     className="drop-down-menu-base__trigger"
     linkToNewTab={false}
     onClickHandler={[Function]}
     shape="rectangle"
-    style="no-style"
+    style="primary"
     type="button"
   >
     trigger

--- a/src/components/__tests__/__snapshots__/drop_down_menu_item.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/drop_down_menu_item.test.tsx.snap
@@ -3,11 +3,12 @@
 exports[`The DropDownMenuItem component should render 1`] = `
 <li>
   <Button
+    appearance="no-style"
     className="drop-down-menu-base__item"
     linkToNewTab={false}
     onClickHandler={[Function]}
     shape="rectangle"
-    style="no-style"
+    style="primary"
     type="button"
   >
     Menu item

--- a/src/components/__tests__/__snapshots__/form.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/form.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`The Form component should render with a form item 1`] = `
             type="submit"
           >
             <button
-              className="btn btn--primary btn--rectangle  disabled"
+              className="btn btn--undefined btn--rectangle  disabled"
               disabled={true}
               onClick={[Function]}
               type="submit"

--- a/src/components/__tests__/__snapshots__/profile_image.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/profile_image.test.tsx.snap
@@ -5,8 +5,8 @@ exports[`The ProfileImage component should render 1`] = `
   className="profile-image"
 >
   <CircleIcon
+    appearance="primary"
     disabled={true}
-    style="primary"
   >
     <Icon(ProfileIcon) />
   </CircleIcon>

--- a/src/components/__tests__/__snapshots__/slide_out_container.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/slide_out_container.test.tsx.snap
@@ -5,11 +5,12 @@ exports[`The SlideOutContainer component should render 1`] = `
   className="slide-out-container"
 >
   <Button
+    appearance="no-style"
     className="slide-out-container__header"
     linkToNewTab={false}
     onClickHandler={[Function]}
     shape="rectangle"
-    style="no-style"
+    style="primary"
     type="button"
   >
     <div

--- a/src/components/__tests__/__snapshots__/user_account_menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/user_account_menu.test.tsx.snap
@@ -58,24 +58,26 @@ exports[`The UserAccountMenu component should display other section 1`] = `
           className="account-section__buttons"
         >
           <Button
+            appearance="secondary"
             className=""
             id="account-menu-manage-button"
             linkToNewTab={true}
             linkURL="https://account-staging.ultimaker.com"
             shape="rectangle"
-            style="secondary"
+            style="primary"
             type="link"
           >
             Manage account
             <Icon(LinkIcon) />
           </Button>
           <Button
+            appearance="secondary"
             className=""
             id="account-menu-sign-out-button"
             linkToNewTab={false}
             onClickHandler={[Function]}
             shape="rectangle"
-            style="secondary"
+            style="primary"
             type="button"
           >
             Sign out
@@ -135,24 +137,26 @@ exports[`The UserAccountMenu component should render 1`] = `
           className="account-section__buttons"
         >
           <Button
+            appearance="secondary"
             className=""
             id="account-menu-manage-button"
             linkToNewTab={true}
             linkURL="https://account-staging.ultimaker.com"
             shape="rectangle"
-            style="secondary"
+            style="primary"
             type="link"
           >
             Manage account
             <Icon(LinkIcon) />
           </Button>
           <Button
+            appearance="secondary"
             className=""
             id="account-menu-sign-out-button"
             linkToNewTab={false}
             onClickHandler={[Function]}
             shape="rectangle"
-            style="secondary"
+            style="primary"
             type="button"
           >
             Sign out
@@ -188,12 +192,13 @@ exports[`The UserAccountMenu component should render sign in button 1`] = `
         className="account-section"
       >
         <Button
+          appearance="secondary"
           className=""
           id="account-menu-sign-in-button"
           linkToNewTab={false}
           onClickHandler={[Function]}
           shape="rectangle"
-          style="secondary"
+          style="primary"
           type="button"
         >
           Sign in

--- a/src/components/__tests__/button.test.tsx
+++ b/src/components/__tests__/button.test.tsx
@@ -3,14 +3,14 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 // component
-import Button from '../button';
+import { Button, ButtonProps } from '../button';
 import Spinner from '../spinner';
 
 // mocks
 import { mockClickEvent } from '../../__mocks__/clickMock';
 
 describe('The Button component', () => {
-    let props;
+    let props: ButtonProps;
     let wrapper;
 
     beforeEach(() => {
@@ -80,20 +80,20 @@ describe('The Button component', () => {
         expect(wrapper.prop('href')).toBeUndefined();
     });
 
-    it('applies the correct class when prop `style` is secondary', () => {
-        wrapper.setProps({ style: 'secondary' });
+    it('applies the correct class when prop `appearance` is secondary', () => {
+        wrapper.setProps({ appearance: 'secondary' });
         expect(wrapper.find('.btn--secondary')).toHaveLength(1);
         expect(wrapper.find('.btn--primary').exists()).toBe(false);
     });
 
-    it('applies the correct class when prop `style` is quiet', () => {
-        wrapper.setProps({ style: 'quiet' });
+    it('applies the correct class when prop `appearance` is quiet', () => {
+        wrapper.setProps({ appearance: 'quiet' });
         expect(wrapper.find('.btn--quiet')).toHaveLength(1);
         expect(wrapper.find('.btn--primary').exists()).toBe(false);
     });
 
-    it('applies the correct class when prop `style` is alert', () => {
-        wrapper.setProps({ style: 'alert' });
+    it('applies the correct class when prop `appearance` is alert', () => {
+        wrapper.setProps({ appearance: 'alert' });
         expect(wrapper.find('.btn--alert')).toHaveLength(1);
         expect(wrapper.find('.btn--primary').exists()).toBe(false);
     });

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import Spinner from './spinner';
 
 export type ButtonType = 'submit' | 'button' | 'link';
-export type ButtonStyle = 'primary' | 'secondary' | 'quiet' | 'alert' | 'link' | 'no-style';
+export type ButtonAppearance = 'primary' | 'secondary' | 'quiet' | 'alert' | 'link' | 'no-style';
 export type ButtonShape = 'rectangle' | 'circle' | 'pill';
 
 export interface ButtonProps {
@@ -19,7 +19,7 @@ export interface ButtonProps {
     /** html button type: 'submit' | 'button' | 'link' */
     type?: ButtonType;
     /** CSS styling: 'primary' | 'secondary' | 'quiet' | 'alert' | 'link' | no-style' */
-    style?: ButtonStyle;
+    appearance?: ButtonAppearance;
     /** Visual shape of the Button: 'rectangle' | 'circle' | 'pill' */
     shape?: ButtonShape;
     /** Replaces the Button text with a spinner when true */
@@ -120,10 +120,10 @@ export class Button extends React.Component<ButtonProps, {}> {
 
     render(): JSX.Element {
         const {
-            disabled, type, style, shape, showSpinner, className,
+            disabled, type, appearance, shape, showSpinner, className,
         } = this.props;
 
-        const classes = classNames(`btn btn--${style} btn--${shape} ${className}`,
+        const classes = classNames(`btn btn--${appearance} btn--${shape} ${className}`,
             { disabled }, { waiting: showSpinner });
 
         if (type === 'link' && this._isLinkInternal()) {

--- a/src/components/circle_icon.tsx
+++ b/src/components/circle_icon.tsx
@@ -5,7 +5,7 @@ export type CircleIconStyle = 'primary' | 'secondary' | 'alert';
 
 export interface CircleIconProps {
     /** CSS styling: 'primary' | 'secondary' | 'alert' */
-    style?: CircleIconStyle;
+    appearance?: CircleIconStyle;
     /** Whether the circle should be should displayed in a disabled state */
     disabled?: boolean;
     /** Size of the icon. Include unit */
@@ -13,10 +13,10 @@ export interface CircleIconProps {
 }
 
 export const CircleIcon: React.StatelessComponent<CircleIconProps> = ({
-    style, disabled, size, children,
+    appearance, disabled, size, children,
 }) => (
     <div
-        className={classNames(`circle-icon icon icon--circle ${style}`, { disabled })}
+        className={classNames(`circle-icon icon icon--circle ${appearance}`, { disabled })}
         style={size ? { width: size, height: size } : undefined}
     >
 
@@ -25,7 +25,7 @@ export const CircleIcon: React.StatelessComponent<CircleIconProps> = ({
 );
 
 CircleIcon.defaultProps = {
-    style: 'primary',
+    appearance: 'primary',
 };
 
 CircleIcon.displayName = 'CircleIcon';

--- a/src/components/close_button.tsx
+++ b/src/components/close_button.tsx
@@ -20,7 +20,7 @@ export const CloseButton: React.StatelessComponent<CloseButtonProps> = ({
     };
 
     return (
-        <Button className="close-button" onClickHandler={_onClickHandler} style="quiet" shape="circle">
+        <Button className="close-button" onClickHandler={_onClickHandler} appearance="quiet" shape="circle">
             <CrossIcon color={color} />
         </Button>
     );

--- a/src/components/drop_down_menu_base.tsx
+++ b/src/components/drop_down_menu_base.tsx
@@ -83,7 +83,7 @@ export class DropDownMenuBase extends React.Component<DropDownMenuBaseProps, {}>
                 onClick={DropDownMenuBase._stopPropagation}
             >
 
-                <Button style="no-style" className="drop-down-menu-base__trigger" onClickHandler={() => this._onToggleMenuHandler(!showMenu)}>
+                <Button appearance="no-style" className="drop-down-menu-base__trigger" onClickHandler={() => this._onToggleMenuHandler(!showMenu)}>
                     {triggerElement}
                 </Button>
 

--- a/src/components/drop_down_menu_item.tsx
+++ b/src/components/drop_down_menu_item.tsx
@@ -26,7 +26,7 @@ const DropDownMenuItem: React.StatelessComponent<DropDownMenuItemProps> = ({
         <Button
             id={id}
             className={classNames('drop-down-menu-base__item', { disabled, active }, className)}
-            style="no-style"
+            appearance="no-style"
             onClickHandler={() => { onCloseMenuHandler(); onClickHandler(); }}
             disabled={disabled}
         >

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button, ButtonStyle } from './button';
+import { Button, ButtonAppearance } from './button';
 import FormActions from './form_actions';
 
 
@@ -17,13 +17,13 @@ export interface FormProps {
     /** Called when the primary button is clicked to submit the form */
     onSubmitHandler: () => void;
     /** Primary button style type */
-    primaryBtnStyle?: ButtonStyle;
+    primaryBtnAppearance?: ButtonAppearance;
     /** Secondary button text */
     secondaryBtnText?: string;
     /** Called when the secondary button is clicked */
     secondaryBtnHandler?: () => void;
     /** Primary button style type */
-    secondaryBtnStyle?: ButtonStyle;
+    secondaryBtnAppearance?: ButtonAppearance;
     /** An internal url link to be used instead of calling secondaryBtnHandler */
     secondaryBtnLink?: string;
     /** Replaces the secondary button text with a spinner when true */
@@ -96,7 +96,7 @@ export class Form extends React.Component<FormProps, FormState> {
 
     render(): JSX.Element {
         const {
-            primaryBtnText, secondaryBtnText, primaryBtnStyle, secondaryBtnStyle,
+            primaryBtnText, secondaryBtnText, primaryBtnAppearance, secondaryBtnAppearance,
             secondaryBtnHandler, secondaryBtnLink, primaryBtnShowSpinner, secondaryBtnShowSpinner,
             children,
         } = this.props;
@@ -110,7 +110,7 @@ export class Form extends React.Component<FormProps, FormState> {
                             {primaryBtnText
                                 && (
                                     <Button
-                                        style={primaryBtnStyle}
+                                        appearance={primaryBtnAppearance}
                                         showSpinner={primaryBtnShowSpinner}
                                         disabled={this._isPrimaryBtnDisabled()}
                                         type="submit"
@@ -123,7 +123,7 @@ export class Form extends React.Component<FormProps, FormState> {
                             {secondaryBtnText
                                 && (
                                     <Button
-                                        style={secondaryBtnStyle}
+                                        appearance={secondaryBtnAppearance}
                                         showSpinner={secondaryBtnShowSpinner}
                                         disabled={primaryBtnShowSpinner}
                                         onClickHandler={secondaryBtnHandler}

--- a/src/components/input_fields/__tests__/__snapshots__/search_field.test.tsx.snap
+++ b/src/components/input_fields/__tests__/__snapshots__/search_field.test.tsx.snap
@@ -22,11 +22,12 @@ exports[`The search field component should render a wrapper 1`] = `
     value="2018"
   >
     <Button
+      appearance="quiet"
       className="search-button"
       linkToNewTab={false}
       onClickHandler={[Function]}
       shape="rectangle"
-      style="quiet"
+      style="primary"
       type="button"
     >
       <Icon(RejectedIcon)

--- a/src/components/input_fields/search_field.tsx
+++ b/src/components/input_fields/search_field.tsx
@@ -87,7 +87,7 @@ export default class SearchField extends React.Component<SearchFieldProps, {}> {
                         : (
                             <Button
                                 onClickHandler={value ? this._onResetHandler : this._focus}
-                                style="quiet"
+                                appearance="quiet"
                                 className="search-button"
                             >
                                 {value ? <RejectedIcon size="sm" /> : <PendingIcon size="sm" />}

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -64,7 +64,7 @@ export default class Navigation extends React.Component<NavigationProps, Navigat
                     <div className="nav-links-container">
                         <div className="burger-menu hide-sm">
                             <Button
-                                style="primary"
+                                appearance="primary"
                                 shape="circle"
                                 onClickHandler={() => this._toggleShowNav(!showNav)}
                             >
@@ -98,7 +98,7 @@ export default class Navigation extends React.Component<NavigationProps, Navigat
 
                                     {onSignOutClickHandler && (
                                         <li style={{ top: `${(visibleNavLinks.length + (manageAccountURL ? 2 : 1)) * x}px` }} className="hide-sm">
-                                            <Button className="nav-link" onClickHandler={onSignOutClickHandler} style="no-style">
+                                            <Button className="nav-link" onClickHandler={onSignOutClickHandler} appearance="no-style">
                                                 <span className="label">{I18n.translate('Nav sign out button', 'Sign out')}</span>
                                             </Button>
                                         </li>

--- a/src/components/popup.tsx
+++ b/src/components/popup.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // components
 import { ModalWidth } from './modal';
 import { Form, FormValidationResponse } from './form';
-import { ButtonStyle } from './button';
+import { ButtonAppearance } from './button';
 import PopupBase from './popup_base';
 
 // utils
@@ -25,8 +25,8 @@ export interface PopupProps {
      * If it returns a promise, the spinner is hidden when it is done
      */
     primaryBtnHandler: () => void | Promise<any>;
-    /** Primary button style */
-    primaryBtnStyle?: ButtonStyle;
+    /** Primary button appearance */
+    primaryBtnAppearance?: ButtonAppearance;
     /** Secondary button text */
     secondaryBtnText?: string;
     /**
@@ -34,8 +34,8 @@ export interface PopupProps {
      * If it returns a promise, the spinner is hidden when it is done
      */
     secondaryBtnHandler?: () => void | Promise<any>;
-    /** Secondary button style */
-    secondaryBtnStyle?: ButtonStyle;
+    /** Secondary button appearance */
+    secondaryBtnAppearance?: ButtonAppearance;
     /** Placeholder text for the input for popups of type prompt */
     promptPlaceholder?: string;
     /** The width of the popup: 'sm' | 'md' */
@@ -124,8 +124,9 @@ export class Popup extends React.Component<PopupProps, PopupState> {
 
     render(): JSX.Element {
         const {
-            headerElement, headerText, bodyText, primaryBtnText, secondaryBtnText, primaryBtnStyle,
-            secondaryBtnStyle, validationErrors, step, totalSteps, width, children, footer,
+            headerElement, headerText, bodyText, primaryBtnText, secondaryBtnText,
+            primaryBtnAppearance, secondaryBtnAppearance, validationErrors, step, totalSteps,
+            width, footer, children,
         } = this.props;
         const { primaryBtnShowSpinner, secondaryBtnShowSpinner } = this.state;
 
@@ -141,11 +142,11 @@ export class Popup extends React.Component<PopupProps, PopupState> {
                 {bodyText && splitTextByNewLine(bodyText)}
                 <Form
                     primaryBtnText={primaryBtnText}
-                    primaryBtnStyle={primaryBtnStyle}
+                    primaryBtnAppearance={primaryBtnAppearance}
                     onSubmitHandler={this._primaryBtnHandler}
                     primaryBtnShowSpinner={primaryBtnShowSpinner}
                     secondaryBtnText={secondaryBtnText}
-                    secondaryBtnStyle={secondaryBtnStyle}
+                    secondaryBtnAppearance={secondaryBtnAppearance}
                     secondaryBtnHandler={this._secondaryBtnHandler}
                     secondaryBtnShowSpinner={secondaryBtnShowSpinner}
                     validationErrors={validationErrors}

--- a/src/components/popup_prompt.tsx
+++ b/src/components/popup_prompt.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // components
 import Popup from './popup';
 import { InputField, InputFieldType, InputFieldValue } from './input_field';
-import { ButtonStyle } from './button';
+import { ButtonAppearance } from './button';
 
 export interface PopupPromptProps {
     /** Input type for popups of type prompt */
@@ -28,8 +28,8 @@ export interface PopupPromptProps {
      * If it returns a promise, the spinner is hidden when it is done.
      */
     primaryBtnHandler: (value: InputFieldValue) => void | Promise<any>;
-    /** Primary button style */
-    primaryBtnStyle?: ButtonStyle;
+    /** Primary button appearance */
+    primaryBtnAppearance?: ButtonAppearance;
     /** Secondary button text */
     secondaryBtnText?: string;
     /**
@@ -37,8 +37,8 @@ export interface PopupPromptProps {
      * If it returns a promise, the spinner is hidden when it is done.
      */
     secondaryBtnHandler?: () => void | Promise<any>;
-    /** Secondary button style */
-    secondaryBtnStyle?: ButtonStyle;
+    /** Secondary button appearance */
+    secondaryBtnAppearance?: ButtonAppearance;
     /** Placeholder text for the input for popups of type prompt */
     promptPlaceholder?: string;
     /** A component or text to be rendered in the footer of the popup */
@@ -108,7 +108,8 @@ export class PopupPrompt extends React.Component<PopupPromptProps, PopupPromptSt
     render(): JSX.Element {
         const {
             headerText, bodyText, primaryBtnText, secondaryBtnText, promptPlaceholder, inputType,
-            inputMin, inputMax, primaryBtnStyle, secondaryBtnStyle, secondaryBtnHandler, footer,
+            inputMin, inputMax, primaryBtnAppearance, secondaryBtnAppearance, secondaryBtnHandler,
+            footer,
         } = this.props;
         const { inputValue, validationError } = this.state;
 
@@ -118,10 +119,10 @@ export class PopupPrompt extends React.Component<PopupPromptProps, PopupPromptSt
                 bodyText={bodyText}
                 primaryBtnText={primaryBtnText}
                 primaryBtnHandler={this._primaryBtnHandler}
-                primaryBtnStyle={primaryBtnStyle}
+                primaryBtnAppearance={primaryBtnAppearance}
                 secondaryBtnText={secondaryBtnText}
                 secondaryBtnHandler={secondaryBtnHandler}
-                secondaryBtnStyle={secondaryBtnStyle}
+                secondaryBtnAppearance={secondaryBtnAppearance}
                 validationErrors={validationError ? { promptInput: validationError } : null}
                 width="sm"
                 footer={footer}

--- a/src/components/profile_image.tsx
+++ b/src/components/profile_image.tsx
@@ -19,7 +19,7 @@ export const ProfileImage: React.StatelessComponent<CircleIconProps> = ({ size, 
         }
         {!imageURL
             && (
-                <CircleIcon style="primary" disabled size={size}>
+                <CircleIcon appearance="primary" disabled size={size}>
                     <ProfileIcon />
                 </CircleIcon>
             )

--- a/src/components/response_error.tsx
+++ b/src/components/response_error.tsx
@@ -123,10 +123,10 @@ export default class ResponseError extends React.Component<ResponseErrorProps, R
                             headerText={I18n.translate('error popup title', 'Something went wrong at our end :(')}
                             bodyText={I18n.translate('error popup details', 'Please describe here what you were doing that caused the error to happen. Then download the report and attach this in an email to your Ultimaker reseller.')}
                             primaryBtnText={I18n.translate('error popup send', 'Download')}
-                            primaryBtnStyle="primary"
+                            primaryBtnAppearance="primary"
                             primaryBtnHandler={this._downloadTextFile}
                             secondaryBtnText={I18n.translate('error popup cancel', 'Cancel')}
-                            secondaryBtnStyle="quiet"
+                            secondaryBtnAppearance="quiet"
                             secondaryBtnHandler={this._closePopup}
                             inputType="textarea"
                             validationHandler={this._validate}

--- a/src/components/slide_out_container.tsx
+++ b/src/components/slide_out_container.tsx
@@ -31,7 +31,7 @@ export const SlideOutContainer: React.StatelessComponent<SlideOutContainerProps>
 
         {headerText && (
             <Button
-                style="no-style"
+                appearance="no-style"
                 className="slide-out-container__header"
                 onClickHandler={() => onHeaderClick()}
             >

--- a/src/components/user_account_menu.tsx
+++ b/src/components/user_account_menu.tsx
@@ -125,7 +125,7 @@ export class UserAccountMenu extends React.Component<UserAccountMenuProps, UserA
                                     <div className="account-section__buttons">
                                         {manageAccountURL && (
                                             <Button
-                                                style="secondary"
+                                                appearance="secondary"
                                                 type="link"
                                                 id="account-menu-manage-button"
                                                 linkURL={manageAccountURL}
@@ -137,7 +137,7 @@ export class UserAccountMenu extends React.Component<UserAccountMenuProps, UserA
                                         )}
 
                                         <Button
-                                            style="secondary"
+                                            appearance="secondary"
                                             onClickHandler={this._onSignOut}
                                             id="account-menu-sign-out-button"
                                         >
@@ -148,7 +148,7 @@ export class UserAccountMenu extends React.Component<UserAccountMenuProps, UserA
                             )}
                             {signedOut && (
                                 <Button
-                                    style="secondary"
+                                    appearance="secondary"
                                     id="account-menu-sign-in-button"
                                     onClickHandler={this._onSignIn}
                                 >

--- a/src/stories/button.stories.tsx
+++ b/src/stories/button.stories.tsx
@@ -23,74 +23,78 @@ stories.addDecorator(withKnobs)
     }));
 
 stories.add('Rectangle', withInfo(
-    'Default button shape with three available styles.',
+    'Default button shape.',
 )(() => (
-    <div className="layout">
-        <div className="layout__item u-fit">
-            <Button
-                onClickHandler={action('clicked')}
-                showSpinner={boolean('Loading', false)}
-                disabled={boolean('Disabled', false)}
-                style="primary"
-            >
-                {text('Text 1', 'Primary')}
-            </Button>
+    <div>
+        <div className="layout">
+            <div className="layout__item u-fit">
+                <Button
+                    onClickHandler={action('clicked')}
+                    showSpinner={boolean('Loading', false)}
+                    disabled={boolean('Disabled', false)}
+                    appearance="primary"
+                >
+                    {text('Text 1', 'Primary')}
+                </Button>
+            </div>
+            <div className="layout__item u-fit">
+                <Button
+                    onClickHandler={action('clicked')}
+                    showSpinner={boolean('Loading', false)}
+                    disabled={boolean('Disabled', false)}
+                    appearance="secondary"
+                >
+                    {text('Text 2', 'Secondary')}
+                </Button>
+            </div>
+            <div className="layout__item u-fit">
+                <Button
+                    onClickHandler={action('clicked')}
+                    showSpinner={boolean('Loading', false)}
+                    disabled={boolean('Disabled', false)}
+                    appearance="quiet"
+                >
+                    {text('Text 3', 'Quiet')}
+                </Button>
+            </div>
+            <div className="layout__item u-fit">
+                <Button
+                    onClickHandler={action('clicked')}
+                    showSpinner={boolean('Loading', false)}
+                    disabled={boolean('Disabled', false)}
+                    appearance="alert"
+                >
+                    {text('Text 4', 'Alert')}
+                </Button>
+            </div>
         </div>
-        <div className="layout__item u-fit">
-            <Button
-                onClickHandler={action('clicked')}
-                showSpinner={boolean('Loading', false)}
-                disabled={boolean('Disabled', false)}
-                style="secondary"
-            >
-                {text('Text 2', 'Secondary')}
-            </Button>
-        </div>
-        <div className="layout__item u-fit">
-            <Button
-                onClickHandler={action('clicked')}
-                showSpinner={boolean('Loading', false)}
-                disabled={boolean('Disabled', false)}
-                style="quiet"
-            >
-                {text('Text 3', 'Quiet')}
-            </Button>
-        </div>
-        <div className="layout__item u-fit">
-            <Button
-                onClickHandler={action('clicked')}
-                showSpinner={boolean('Loading', false)}
-                disabled={boolean('Disabled', false)}
-                style="alert"
-            >
-                {text('Text 4', 'Alert')}
-            </Button>
-        </div>
-        <div className="layout__item u-fit">
-            <Button
-                onClickHandler={action('clicked')}
-                showSpinner={boolean('Loading', false)}
-                disabled={boolean('Disabled', false)}
-                style="link"
-            >
-                {text('Text 5', 'Link')}
-            </Button>
-        </div>
-        <div className="layout__item u-fit">
-            <Button
-                onClickHandler={action('clicked')}
-                showSpinner={boolean('Loading', false)}
-                disabled={boolean('Disabled', false)}
-                style="no-style"
-            >
-                {text('Text 6', 'No style')}
-            </Button>
+        <div className="layout layout--align-center" style={{ marginTop: '2.4rem' }}>
+            <div className="layout__item u-fit">
+                <Button
+                    onClickHandler={action('clicked')}
+                    showSpinner={boolean('Loading', false)}
+                    disabled={boolean('Disabled', false)}
+                    appearance="link"
+                >
+                    {text('Text 5', 'Link')}
+                </Button>
+            </div>
+            <div className="layout__item u-fit">
+                <Button
+                    onClickHandler={action('clicked')}
+                    showSpinner={boolean('Loading', false)}
+                    disabled={boolean('Disabled', false)}
+                    appearance="no-style"
+                >
+                    {text('Text 6', 'No style')}
+                </Button>
+            </div>
         </div>
     </div>
 )));
 
 stories.add('Circle', withInfo(
-    'Round button shape with three available styles. Can be used for action buttons on mobile.',
+    'Round button shape. Can be used for action buttons on mobile.',
 )(() => (
     <div className="layout">
         <div className="layout__item u-fit">
@@ -98,7 +102,7 @@ stories.add('Circle', withInfo(
                 onClickHandler={action('clicked')}
                 showSpinner={boolean('Loading', false)}
                 disabled={boolean('Disabled', false)}
-                style="primary"
+                appearance="primary"
                 shape="circle"
             >
                 {text('Text 1', 'P')}
@@ -109,7 +113,7 @@ stories.add('Circle', withInfo(
                 onClickHandler={action('clicked')}
                 showSpinner={boolean('Loading', false)}
                 disabled={boolean('Disabled', false)}
-                style="secondary"
+                appearance="secondary"
                 shape="circle"
             >
                 {text('Text 2', 'S')}
@@ -120,7 +124,7 @@ stories.add('Circle', withInfo(
                 onClickHandler={action('clicked')}
                 showSpinner={boolean('Loading', false)}
                 disabled={boolean('Disabled', false)}
-                style="quiet"
+                appearance="quiet"
                 shape="circle"
             >
                 {text('Text 3', 'Q')}
@@ -131,7 +135,7 @@ stories.add('Circle', withInfo(
                 onClickHandler={action('clicked')}
                 showSpinner={boolean('Loading', false)}
                 disabled={boolean('Disabled', false)}
-                style="alert"
+                appearance="alert"
                 shape="circle"
             >
                 {text('Text 4', 'A')}
@@ -141,7 +145,7 @@ stories.add('Circle', withInfo(
 )));
 
 stories.add('Pill', withInfo(
-    'Long rounded button shape with three available styles. Can be used for filter buttons.',
+    'Long rounded button shape. Can be used for filter buttons.',
 )(() => (
     <div className="layout">
         <div className="layout__item u-fit">
@@ -149,7 +153,7 @@ stories.add('Pill', withInfo(
                 onClickHandler={action('clicked')}
                 showSpinner={boolean('Loading', false)}
                 disabled={boolean('Disabled', false)}
-                style="primary"
+                appearance="primary"
                 shape="pill"
             >
                 {text('Text 1', 'Primary')}
@@ -160,7 +164,7 @@ stories.add('Pill', withInfo(
                 onClickHandler={action('clicked')}
                 showSpinner={boolean('Loading', false)}
                 disabled={boolean('Disabled', false)}
-                style="secondary"
+                appearance="secondary"
                 shape="pill"
             >
                 {text('Text 2', 'Secondary')}
@@ -171,7 +175,7 @@ stories.add('Pill', withInfo(
                 onClickHandler={action('clicked')}
                 showSpinner={boolean('Loading', false)}
                 disabled={boolean('Disabled', false)}
-                style="quiet"
+                appearance="quiet"
                 shape="pill"
             >
                 {text('Text 3', 'Quiet')}
@@ -182,7 +186,7 @@ stories.add('Pill', withInfo(
                 onClickHandler={action('clicked')}
                 showSpinner={boolean('Loading', false)}
                 disabled={boolean('Disabled', false)}
-                style="alert"
+                appearance="alert"
                 shape="pill"
             >
                 {text('Text 3', 'Alert')}
@@ -218,7 +222,7 @@ stories.add('Link button', withInfo(
             linkToNewTab={boolean('Link to new tab', false)}
             showSpinner={boolean('Loading', false)}
             disabled={boolean('Disabled', false)}
-            style="primary"
+            appearance="primary"
         >
             {text('Text 1', 'Link')}
         </Button>

--- a/src/stories/layout_form.stories.tsx
+++ b/src/stories/layout_form.stories.tsx
@@ -57,7 +57,7 @@ stories.add('Form', withState({
                 onSubmitHandler={action('submit')}
                 secondaryBtnText="Cancel"
                 secondaryBtnHandler={action('clicked')}
-                secondaryBtnStyle="quiet"
+                secondaryBtnAppearance="quiet"
                 validationErrors={{
                     id_1: 'Validation error 1',
                     id_2: 'Validation error 2',

--- a/src/stories/modal.stories.tsx
+++ b/src/stories/modal.stories.tsx
@@ -45,10 +45,10 @@ stories.add('Confirm popup', withInfo(
         bodyText="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
         primaryBtnText="Confirm"
         primaryBtnHandler={action('clicked')}
-        primaryBtnStyle="primary"
+        primaryBtnAppearance="primary"
         secondaryBtnText="Cancel"
         secondaryBtnHandler={action('clicked')}
-        secondaryBtnStyle="quiet"
+        secondaryBtnAppearance="quiet"
         width={selectV2('Popup width', widthOptions, widthDefaultValue)}
         footer={text('Footer')}
     />
@@ -85,10 +85,10 @@ stories.add('Prompt popup', withInfo(
         bodyText="Input a number:"
         primaryBtnText="Confirm"
         primaryBtnHandler={action('clicked')}
-        primaryBtnStyle="primary"
+        primaryBtnAppearance="primary"
         secondaryBtnText="Cancel"
         secondaryBtnHandler={action('clicked')}
-        secondaryBtnStyle="quiet"
+        secondaryBtnAppearance="quiet"
         inputDefaultValue={10}
         validationHandler={validation}
         inputType="number"
@@ -149,10 +149,10 @@ stories.add('Multi-step popup', withState({ step: 1 })(withInfo('Multi-step popu
         bodyText={getBodyText(store.state.step)}
         primaryBtnText={getPrimaryBtnText(store.state.step)}
         primaryBtnHandler={() => store.set({ step: validateStep(store.state.step + 1, 3) })}
-        primaryBtnStyle="primary"
+        primaryBtnAppearance="primary"
         secondaryBtnText={getSecondaryBtnText(store.state.step)}
         secondaryBtnHandler={() => store.set({ step: validateStep(store.state.step - 1, 3) })}
-        secondaryBtnStyle="quiet"
+        secondaryBtnAppearance="quiet"
         step={store.state.step}
         totalSteps={3}
         width={selectV2('Popup width', widthOptions, widthDefaultValue)}

--- a/src/stories/other.stories.tsx
+++ b/src/stories/other.stories.tsx
@@ -68,17 +68,17 @@ stories.add('Pill', withInfo(
     </Tile>
 )));
 
-const styleOptions = {
+const appearanceOptions = {
     primary: 'primary',
     secondary: 'secondary',
     alert: 'alert',
 };
-const styleValue = 'primary';
+const appearanceValue = 'primary';
 
 stories.add('Circle Icon', withInfo(
     'A circle icon',
 )(() => (
-    <CircleIcon style={selectV2('Style', styleOptions, styleValue)} disabled={boolean('Disabled', false)} size={text('Size', '4rem')}>
+    <CircleIcon appearance={selectV2('Appearance', appearanceOptions, appearanceValue)} disabled={boolean('Disabled', false)} size={text('Size', '4rem')}>
         {text('Text', '1')}
     </CircleIcon>
 )));


### PR DESCRIPTION
To avoid names clashing, the attributte 'style' should only be used for in-line styling. All other uses will be changed to 'appearance'.