### PR TITLE
remove onCloseMenuHandler from the drop down menu

### DIFF
--- a/src/components/__tests__/__snapshots__/context_menu_item.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/context_menu_item.test.tsx.snap
@@ -4,6 +4,5 @@ exports[`The ContextMenuItem component should render 1`] = `
 <DropDownMenuItem
   active={false}
   onClickHandler={[MockFunction]}
-  onCloseMenuHandler={[MockFunction]}
 />
 `;

--- a/src/components/__tests__/__snapshots__/drop_down_menu_base.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/drop_down_menu_base.test.tsx.snap
@@ -48,13 +48,14 @@ exports[`The DropDownMenuBase component should render 1`] = `
         >
           <DropDownMenuItem
             active={false}
-            key=".0"
             onClickHandler={[MockFunction]}
-            onCloseMenuHandler={[Function]}
           />
         </ul>
       </Collapse>
     </div>
+    <div
+      className="drop-down-menu-base__arrow"
+    />
   </div>
 </div>
 `;

--- a/src/components/__tests__/drop_down_menu_item.test.tsx
+++ b/src/components/__tests__/drop_down_menu_item.test.tsx
@@ -14,7 +14,6 @@ describe('The DropDownMenuItem component', () => {
         props = {
             active: false,
             onClickHandler: jest.fn(),
-            onCloseMenuHandler: jest.fn(),
         };
         wrapper = shallow(<DropDownMenuItem {...props}>Menu item</DropDownMenuItem>);
     });
@@ -27,7 +26,6 @@ describe('The DropDownMenuItem component', () => {
     it('should call the click handler when item is clicked', () => {
         wrapper.find(Button).props().onClickHandler();
         expect(props.onClickHandler).toHaveBeenCalled();
-        expect(props.onCloseMenuHandler).toHaveBeenCalled();
     });
 
     it('should render item as disabled', () => {

--- a/src/components/context_menu_item.tsx
+++ b/src/components/context_menu_item.tsx
@@ -12,12 +12,10 @@ export interface ContextMenuItemProps {
     id?: string;
     /** Optional class for the menu item */
     className?: string;
-    /** Passed by the DropDownMenuBase component */
-    onCloseMenuHandler?: () => void;
 }
 
 export const ContextMenuItem: React.StatelessComponent<ContextMenuItemProps> = ({
-    disabled, onClickHandler, id, className, onCloseMenuHandler, children,
+    disabled, onClickHandler, id, className, children,
 }) => (
     <DropDownMenuItem
         active={false}
@@ -25,7 +23,6 @@ export const ContextMenuItem: React.StatelessComponent<ContextMenuItemProps> = (
         onClickHandler={onClickHandler}
         id={id}
         className={className}
-        onCloseMenuHandler={onCloseMenuHandler}
     >
         {children}
     </DropDownMenuItem>

--- a/src/components/drop_down_menu_base.tsx
+++ b/src/components/drop_down_menu_base.tsx
@@ -31,24 +31,6 @@ export class DropDownMenuBase extends React.Component<DropDownMenuBaseProps, {}>
         e.stopPropagation();
     }
 
-    /**
-     * Determines whether a child component is in the list of components
-     * that require the onCloseMenuHandler prop to be added
-     * @param child - the child component
-     */
-    static _isHandlerRequired(child: any): boolean {
-        const componentList = {
-            DropDownMenuItem: true,
-            ContextMenuItem: true,
-        };
-
-        if (child.type && child.type.displayName && componentList[child.type.displayName]) {
-            return true;
-        }
-
-        return false;
-    }
-
     constructor(props: DropDownMenuBaseProps) {
         super(props);
         this._menuRef = React.createRef();
@@ -60,7 +42,6 @@ export class DropDownMenuBase extends React.Component<DropDownMenuBaseProps, {}>
 
     private _onOutsideFocusHandler(event): void {
         if (this._menuRef && !this._menuRef.current.contains(event.target)) {
-            // close menu is user clicks or tabs outside
             this._onToggleMenuHandler(false);
         }
 
@@ -120,16 +101,11 @@ export class DropDownMenuBase extends React.Component<DropDownMenuBaseProps, {}>
                             springConfig={{ stiffness: 370, damping: 35 }}
                         >
                             <ul className="drop-down-menu-base__menu-list">
-                                {React.Children.map(children, (child: JSX.Element) => (
-                                    React.cloneElement(
-                                        child,
-                                        DropDownMenuBase._isHandlerRequired(child)
-                                            && onCloseMenuHandlerProp,
-                                    )
-                                ))}
+                                {children}
                             </ul>
                         </Collapse>
                     </div>
+                    <div className="drop-down-menu-base__arrow" />
                 </div>
 
             </div>

--- a/src/components/drop_down_menu_item.tsx
+++ b/src/components/drop_down_menu_item.tsx
@@ -15,19 +15,17 @@ export interface DropDownMenuItemProps {
     id?: string;
     /** Optional class for the menu item */
     className?: string;
-    /** Passed by the DropDownMenuBase component */
-    onCloseMenuHandler?: () => void;
 }
 
 const DropDownMenuItem: React.StatelessComponent<DropDownMenuItemProps> = ({
-    active, disabled, onClickHandler, onCloseMenuHandler, id, className, children,
+    active, disabled, onClickHandler, id, className, children,
 }) => (
     <li>
         <Button
             id={id}
             className={classNames('drop-down-menu-base__item', { disabled, active }, className)}
             appearance="no-style"
-            onClickHandler={() => { onCloseMenuHandler(); onClickHandler(); }}
+            onClickHandler={() => { onClickHandler(); }}
             disabled={disabled}
         >
             {children}

--- a/src/components/spinner.tsx
+++ b/src/components/spinner.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-const Spinner: React.StatelessComponent<{}> = () => (
+export const Spinner: React.StatelessComponent<{}> = () => (
     <div className="spinner">
         <svg width="65px" height="65px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
             <circle className="path" fill="none" strokeWidth="6" strokeLinecap="round" cx="33" cy="33" r="30" />

--- a/src/stylesheets/_drop_down_menu_base.scss
+++ b/src/stylesheets/_drop_down_menu_base.scss
@@ -10,20 +10,19 @@
         position: absolute;
         bottom: 3px;
         width: 100%;
+        z-index: 99998;
 
-        &:before {
+        .drop-down-menu-base__arrow {
             background: white;
             border-top: 1px solid $context-menu-color-chevron-shadow;
             border-left: 1px solid $context-menu-color-chevron-shadow;
             border-width: 1px 0 0 1px;
-            content: "";
             height: 1rem;
             left: 50%;
             position: absolute;
             transform: translate(-50%, 0) rotate(45deg);
             top: -6px;
             width: 1rem;
-            z-index: 99999;
         }
     }
 
@@ -33,7 +32,6 @@
         color: $context-menu-color-text;
         position: absolute;
         border-radius: 1px;
-        z-index: 99998;
         box-shadow: 0 0.1rem 0.2rem 0.1rem $color-shadow;
 
         ul {
@@ -48,7 +46,7 @@
             bottom: auto;
             top: 0;
 
-            &:before {
+            .drop-down-menu-base__arrow {
                 top: -5px;
                 border: none;
                 border-bottom: 1px solid $context-menu-color-chevron-shadow;


### PR DESCRIPTION
An onCloseMenuHandler was passed from DropDownMenuBase to DropDownMenuItem, but this is causing some issues in cura connect. To simplify things, closing the menu on item click will be removed. Closing the menu on click outside will still work.
CL-1207