### PR TITLE
Import the old way for now

### DIFF
--- a/src/components/image_cropper.tsx
+++ b/src/components/image_cropper.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) 2018 Ultimaker B.V.
 import * as React from 'react';
-import * as debounce from 'lodash.debounce';
 
 import { ImageShape } from './image';
 import RangeSlider from './range_slider';
@@ -13,6 +12,8 @@ if ('default' in AvatarEditor) {
     /* istanbul ignore next */ // ignores coverage for this line.
     AvatarEditor = AvatarEditor.default;
 }
+
+const debounce = require('lodash.debounce');
 
 export interface ImageCropperProps {
     /** Size of the image. Include size unit */


### PR DESCRIPTION
To keep both parcel and webpack happy, lodash functions need to be imported this way for now.