### PR TITLE
Specify --unsafe-perm on publish

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,6 @@ publish:
     - yarn build
     - npm --no-git-tag-version version from-git
     - GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i ${CI_PROJECT_DIR}/id_rsa" git push git@github.com:Ultimaker/react-web-components.git HEAD:master
-    - npm publish
+    - npm --unsafe-perm publish
   only:
     - tags


### PR DESCRIPTION
Because the process is running as root inside the docker container.