### PR TITLE
Fix carousel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "node-gettext": "^2.0.0",
         "prop-types": "^15.7.1",
         "react": "^16.4.2",
-        "react-alice-carousel": "^1.13.0",
+        "react-alice-carousel": "^1.14.0",
         "react-avatar-editor": "^11.0.4",
         "react-date-picker": "^7.2.0",
         "react-dom": "^16.4.2",

--- a/src/components/__tests__/__snapshots__/carousel.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/carousel.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`The carousel component should render a carousel 1`] = `
     className="carousel__carousel"
   >
     <AliceCarousel
+      autoHeight={false}
       autoPlay={true}
       autoPlayDirection="ltr"
       autoPlayInterval={5000}
@@ -148,6 +149,7 @@ exports[`The carousel component should render a grid and a carousel 1`] = `
     className="carousel__carousel hide-md"
   >
     <AliceCarousel
+      autoHeight={false}
       autoPlay={true}
       autoPlayDirection="ltr"
       autoPlayInterval={5000}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -50,7 +50,7 @@
 @import "range_slider";
 @import "video_player";
 @import "aspect_ratio_container";
-@import "~react-alice-carousel/src/alice-carousel";
+@import "~react-alice-carousel/lib/scss/alice-carousel";
 @import "carousel";
 @import "generic_flow_page";
 @import "resource_tile";

--- a/yarn.lock
+++ b/yarn.lock
@@ -8905,13 +8905,13 @@ react-addons-create-fragment@^15.5.3:
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
 
-react-alice-carousel@^1.13.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/react-alice-carousel/-/react-alice-carousel-1.13.1.tgz#6c3d1d8f5358cafd6a90de3212c3d424fc48dfe0"
-  integrity sha512-FK+K3WRwFUh/jQHld5P4Mi3swguhBsEotYT6iG5Sg/+C96Fi2YFnqt+cVB2ssfWJXMXqz5kvq6Z4ZfbFZrf0pA==
+react-alice-carousel@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/react-alice-carousel/-/react-alice-carousel-1.14.0.tgz#5380981a0dc5988d133eb10c89bb9a6ac3bbf2e4"
+  integrity sha512-H3qf+BYT0gCFDcX9OwSTrjSTVpbrah147RJ95QRm5o8CiFfn6TRD/YNcEqQ6iRYa4cjHEpzeFcYodq/oxpGsgA==
   dependencies:
     prop-types "^15.5.10"
-    react-swipeable "^4.3.0"
+    react-swipeable "4.3.0"
 
 react-avatar-editor@^11.0.4:
   version "11.0.6"
@@ -9192,10 +9192,10 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-swipeable@^4.3.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-4.3.2.tgz#8bacfd17f74bd24bdd770fc522739dbdc9a9d493"
-  integrity sha512-DPZ5FbefHk2XtbLIMqa7LKwqDPHRezPrcBVg4M2beeRohlmEK2hGsYj81lReEnX6AChOJZtYBvBSxGIIwpG38A==
+react-swipeable@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-4.3.0.tgz#818c0818ac565f5b169348f442153f343abff8bc"
+  integrity sha512-L21VMbcDvG+AOVF4ZIbQ8sICGIgiKB/plGKWBMw6dkxt5neS7x74ZlTbJ39U8slz798MZBv/uIoE9Vzgp3PODQ==
   dependencies:
     detect-passive-events "^1.0.4"
     prop-types "^15.5.8"


### PR DESCRIPTION
Updates react-alice-carousel to 1.14.0 and using the new import location of that library. Was already done in some project using this library as we used 1.13.0 and higher as dependency. Component tested using the storybook UI.