### PR TITLE
CS-125 Fix shifting header items

### DIFF
--- a/src/components/__tests__/slide_in_panel.test.tsx
+++ b/src/components/__tests__/slide_in_panel.test.tsx
@@ -6,7 +6,7 @@ import { shallow, mount } from 'enzyme';
 import SlideInPanel from '../slide_in_panel';
 
 // utils
-import {wheelOverride, keydownOverride} from '../../utils/toggle_scrolling'
+import * as toggleScrolling from '../../utils/toggle_scrolling'
 
 // mocks
 import { mockClickEvent } from '../../__mocks__/clickMock';
@@ -14,6 +14,8 @@ import { mockClickEvent } from '../../__mocks__/clickMock';
 describe('The SlideInPanel component', () => {
     let props;
     let wrapper;
+    let enableScrollingSpy;
+    let disableScrollingSpy;
 
     beforeEach(() => {
         props = {
@@ -28,6 +30,8 @@ describe('The SlideInPanel component', () => {
                 <div>Footer</div>
             </SlideInPanel>,
         );
+        enableScrollingSpy = jest.spyOn(toggleScrolling, 'enableScrolling');
+        disableScrollingSpy = jest.spyOn(toggleScrolling, 'disableScrolling');
     });
 
     it('should render', () => {
@@ -61,30 +65,16 @@ describe('The SlideInPanel component', () => {
         expect(wrapper.render()).toMatchSnapshot();
     });
 
-    it('should not allow the background to scroll when open', () => {
-        const { id } = wrapper.state();
-        expect(window.onmousewheel).toBeFalsy();
-        expect(document.onscroll).toBeFalsy();
-        expect(document.onkeydown).toBeFalsy();
+    it('should disable scrolling when opened', () => {
         wrapper.setProps({ isOpen: true });
-        expect(window.onmousewheel).toBe(wheelOverride);
-        expect(document.onscroll).toBe(wheelOverride);
-        expect(document.onkeydown).toBe(keydownOverride);
+        expect(disableScrollingSpy).toHaveBeenCalled();
         wrapper.setProps({ isOpen: false });
-        expect(window.onmousewheel).toBeFalsy();
-        expect(document.onscroll).toBeFalsy();
-        expect(document.onkeydown).toBeFalsy();
+        expect(enableScrollingSpy).toHaveBeenCalled();
     });
 
-    it('should allow the background to scroll after unmount', () => {
-        const { id } = wrapper.state();
+    it('should re-enable scrolling after unmount', () => {
         wrapper.setProps({ isOpen: true });
-        expect(window.onmousewheel).toBe(wheelOverride);
-        expect(document.onscroll).toBe(wheelOverride);
-        expect(document.onkeydown).toBe(keydownOverride);
         wrapper.unmount();
-        expect(window.onmousewheel).toBeFalsy();
-        expect(document.onscroll).toBeFalsy();
-        expect(document.onkeydown).toBeFalsy();
+        expect(enableScrollingSpy).toHaveBeenCalled();
     });
 });

--- a/src/components/__tests__/slide_in_panel.test.tsx
+++ b/src/components/__tests__/slide_in_panel.test.tsx
@@ -5,6 +5,9 @@ import { shallow, mount } from 'enzyme';
 // component
 import SlideInPanel from '../slide_in_panel';
 
+// utils
+import {wheelOverride, keydownOverride} from '../../utils/toggle_scrolling'
+
 // mocks
 import { mockClickEvent } from '../../__mocks__/clickMock';
 
@@ -60,18 +63,28 @@ describe('The SlideInPanel component', () => {
 
     it('should not allow the background to scroll when open', () => {
         const { id } = wrapper.state();
-        expect(document.body.classList.contains(`noscroll-${id}`)).toBe(false);
+        expect(window.onmousewheel).toBeFalsy();
+        expect(document.onscroll).toBeFalsy();
+        expect(document.onkeydown).toBeFalsy();
         wrapper.setProps({ isOpen: true });
-        expect(document.body.classList.contains(`noscroll-${id}`)).toBe(true);
+        expect(window.onmousewheel).toBe(wheelOverride);
+        expect(document.onscroll).toBe(wheelOverride);
+        expect(document.onkeydown).toBe(keydownOverride);
         wrapper.setProps({ isOpen: false });
-        expect(document.body.classList.contains(`noscroll-${id}`)).toBe(false);
+        expect(window.onmousewheel).toBeFalsy();
+        expect(document.onscroll).toBeFalsy();
+        expect(document.onkeydown).toBeFalsy();
     });
 
     it('should allow the background to scroll after unmount', () => {
         const { id } = wrapper.state();
         wrapper.setProps({ isOpen: true });
-        expect(document.body.classList.contains(`noscroll-${id}`)).toBe(true);
+        expect(window.onmousewheel).toBe(wheelOverride);
+        expect(document.onscroll).toBe(wheelOverride);
+        expect(document.onkeydown).toBe(keydownOverride);
         wrapper.unmount();
-        expect(document.body.classList.contains(`noscroll-${id}`)).toBe(false);
+        expect(window.onmousewheel).toBeFalsy();
+        expect(document.onscroll).toBeFalsy();
+        expect(document.onkeydown).toBeFalsy();
     });
 });

--- a/src/components/slide_in_panel.tsx
+++ b/src/components/slide_in_panel.tsx
@@ -3,7 +3,7 @@ import { Spring, animated } from 'react-spring';
 import classNames from 'classnames';
 
 // utils
-import { enable_scrolling, disable_scrolling } from "../utils/toggle_scrolling"
+import { enableScrolling, disableScrolling } from '../utils/toggle_scrolling';
 
 export interface SlideInPanelHeaderLabels {
     label: string
@@ -51,9 +51,9 @@ export class SlideInPanel extends React.Component<SlideInPanelProps, SlideInPane
 
         if (prevProps.isOpen !== isOpen) {
             if (isOpen) {
-                disable_scrolling();
+                disableScrolling();
             } else {
-                enable_scrolling();
+                enableScrolling();
             }
         }
     }
@@ -61,7 +61,7 @@ export class SlideInPanel extends React.Component<SlideInPanelProps, SlideInPane
     componentWillUnmount(): void {
         const { id } = this.state;
 
-        enable_scrolling();
+        enableScrolling();
     }
 
     private _handleOverlayClick(e: React.MouseEvent<HTMLDivElement>): void {

--- a/src/components/slide_in_panel.tsx
+++ b/src/components/slide_in_panel.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { Spring, animated } from 'react-spring';
 import classNames from 'classnames';
 
+// utils
+import { enable_scrolling, disable_scrolling } from "../utils/toggle_scrolling"
+
 export interface SlideInPanelHeaderLabels {
     label: string
     info?: string
@@ -48,9 +51,9 @@ export class SlideInPanel extends React.Component<SlideInPanelProps, SlideInPane
 
         if (prevProps.isOpen !== isOpen) {
             if (isOpen) {
-                document.body.classList.add(`noscroll-${id}`);
+                disable_scrolling();
             } else {
-                document.body.classList.remove(`noscroll-${id}`);
+                enable_scrolling();
             }
         }
     }
@@ -58,7 +61,7 @@ export class SlideInPanel extends React.Component<SlideInPanelProps, SlideInPane
     componentWillUnmount(): void {
         const { id } = this.state;
 
-        document.body.classList.remove(`noscroll-${id}`);
+        enable_scrolling();
     }
 
     private _handleOverlayClick(e: React.MouseEvent<HTMLDivElement>): void {

--- a/src/utils/__tests__/toggle_scrolling.tsx
+++ b/src/utils/__tests__/toggle_scrolling.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2018 Ultimaker B.V.
+import * as React from 'react';
+import { shallow, mount } from 'enzyme';
+
+// utils
+import { enableScrolling, disableScrolling } from '../../utils/toggle_scrolling'
+
+describe('disableScrolling', () => {
+    let mouseScrollEvent;
+    let scrollKeyEvent;
+    let otherKeyEvent;
+
+    beforeEach(() => {
+        mouseScrollEvent = new Event('DOMMouseScroll');
+        mouseScrollEvent.stopPropagation = jest.fn();
+        mouseScrollEvent.preventDefault = jest.fn();
+
+        scrollKeyEvent = new KeyboardEvent('keydown', {'code': 'ArrowDown'});
+        scrollKeyEvent.preventDefault = jest.fn();
+    
+        otherKeyEvent = new KeyboardEvent('keydown', {'code': 'KeyA'});
+        otherKeyEvent.preventDefault = jest.fn();
+        
+        disableScrolling();
+    });
+
+    it('should prevent mouse wheel behavior', () => {
+        window.dispatchEvent(mouseScrollEvent);
+        expect(mouseScrollEvent.preventDefault).toBeCalled();
+    });
+
+    it('should prevent keyboard scroll behavior', () => {
+        document.dispatchEvent(scrollKeyEvent);
+        expect(scrollKeyEvent.preventDefault).toBeCalled();
+    });
+
+    it('should not prevent other keyboard key presses', () => {
+        document.dispatchEvent(otherKeyEvent);
+        expect(otherKeyEvent.preventDefault).not.toBeCalled();
+    });
+});
+
+describe('enableScrolling', () => {
+    let mouseScrollEvent;
+    let scrollKeyEvent;
+    let otherKeyEvent;
+
+    beforeEach(() => {
+        mouseScrollEvent = new Event('DOMMouseScroll');
+        mouseScrollEvent.stopPropagation = jest.fn();
+        mouseScrollEvent.preventDefault = jest.fn();
+
+        scrollKeyEvent = new KeyboardEvent('keydown', {'code': 'ArrowDown'});
+        scrollKeyEvent.preventDefault = jest.fn();
+        
+        otherKeyEvent = new KeyboardEvent('keydown', {'code': 'KeyA'});
+        otherKeyEvent.preventDefault = jest.fn();
+        
+        enableScrolling();
+    });
+
+    it('should allow mouse wheel behavior', () => {
+        window.dispatchEvent(mouseScrollEvent);
+        expect(mouseScrollEvent.preventDefault).not.toBeCalled();
+    });
+
+    it('should allow keyboard scroll behavior', () => {    
+        document.dispatchEvent(scrollKeyEvent);
+        expect(scrollKeyEvent.preventDefault).not.toBeCalled();   
+    });
+
+    it('should not prevent other keyboard key presses', () => {
+        document.dispatchEvent(otherKeyEvent);
+        expect(otherKeyEvent.preventDefault).not.toBeCalled();
+    });
+});
+
+
+
+
+

--- a/src/utils/toggle_scrolling.tsx
+++ b/src/utils/toggle_scrolling.tsx
@@ -1,8 +1,16 @@
 // Adapted from from https://stackoverflow.com/a/4770179
 
-// spacebar: 32, pageup: 33, pagedown: 34, end: 35, home: 36
-// left: 37, up: 38, right: 39, down: 40,
-const scrollKeys = [32, 33, 34, 35, 36, 37, 38, 39, 40];
+const scrollKeys = [
+    "Space", // space
+    "PageDown", // page up
+    "PageDown", // page down
+    "End", // end
+    "Home", // home
+    "ArrowLeft", // left
+    "ArrowUp", // up
+    "ArrowRight", // right
+    "ArrowDown" // down
+];
 
 /**
  * Robust way to really block default behavior.
@@ -21,7 +29,7 @@ function preventDefault(e: any = window.event): void {
  */
 export function keydownOverride(e: any): void {
     scrollKeys.forEach((code) => {
-        if (e.keyCode === code) {
+        if (e.code == code) {
             preventDefault(e);
         }
     });

--- a/src/utils/toggle_scrolling.tsx
+++ b/src/utils/toggle_scrolling.tsx
@@ -28,41 +28,25 @@ export function keydownOverride(e: any): void {
 }
 
 /**
- * This is a replacement to the build-in 'mousewheel' and 'scroll' handlers in the browser.
- * @param e - Event object.
- */
-export function wheelOverride(e: any): void {
-    preventDefault(e);
-}
-
-/**
  * Enable scrolling in the DOM.
  */
 export function enableScrolling(): void {
-    if (window.removeEventListener) {
-        window.removeEventListener('DOMMouseScroll', wheelOverride, false); // desktop
-    }
-    if (document.removeEventListener) {
-        document.removeEventListener('touchmove', preventDefault, false); // mobile
-    }
+    window.removeEventListener('DOMMouseScroll', preventDefault, false); // desktop
+    document.removeEventListener('touchmove', preventDefault, true); // mobile
+    document.removeEventListener('keydown', keydownOverride, true);
     window.onmousewheel = null;
     document.onscroll = null;
-    document.onkeydown = null;
 }
 
 /**
  * Disable scrolling in the DOM.
  */
 export function disableScrolling(): void {
-    if (window.addEventListener) {
-        window.addEventListener('DOMMouseScroll', wheelOverride, false); // desktop
-    }
-    if (document.addEventListener) {
-        document.addEventListener('touchmove', preventDefault, false); // mobile
-    }
-    window.onmousewheel = wheelOverride;
-    document.onscroll = wheelOverride;
-    document.onkeydown = keydownOverride;
+    window.addEventListener('DOMMouseScroll', preventDefault, false); // desktop
+    document.addEventListener('touchmove', preventDefault, true); // mobile
+    document.addEventListener('keydown', keydownOverride, true);
+    window.onmousewheel = preventDefault;
+    document.onscroll = preventDefault;
 }
 
 export default { enableScrolling, disableScrolling };

--- a/src/utils/toggle_scrolling.tsx
+++ b/src/utils/toggle_scrolling.tsx
@@ -19,7 +19,7 @@ function preventDefault(e: any = window.event): void {
  * This is a replacement to the build-in 'keydown' handler in the browser.
  * @param e - Event object.
  */
-function keydownOverride(e: any): void {
+export function keydownOverride(e: any): void {
     scrollKeys.forEach((code) => {
         if (e.keyCode === code) {
             preventDefault(e);
@@ -31,7 +31,7 @@ function keydownOverride(e: any): void {
  * This is a replacement to the build-in 'mousewheel' and 'scroll' handlers in the browser.
  * @param e - Event object.
  */
-function wheelOverride(e: any): void {
+export function wheelOverride(e: any): void {
     preventDefault(e);
 }
 
@@ -42,10 +42,12 @@ export function enableScrolling(): void {
     if (window.removeEventListener) {
         window.removeEventListener('DOMMouseScroll', wheelOverride, false); // desktop
     }
+    if (document.removeEventListener) {
+        document.removeEventListener('touchmove', preventDefault, false); // mobile
+    }
     window.onmousewheel = null;
     document.onscroll = null;
     document.onkeydown = null;
-    document.removeEventListener('touchmove', preventDefault, false); // mobile
 }
 
 /**
@@ -55,10 +57,12 @@ export function disableScrolling(): void {
     if (window.addEventListener) {
         window.addEventListener('DOMMouseScroll', wheelOverride, false); // desktop
     }
+    if (document.addEventListener) {
+        document.addEventListener('touchmove', preventDefault, false); // mobile
+    }
     window.onmousewheel = wheelOverride;
     document.onscroll = wheelOverride;
     document.onkeydown = keydownOverride;
-    document.addEventListener('touchmove', preventDefault, false); // mobile
 }
 
 export default { enableScrolling, disableScrolling };

--- a/src/utils/toggle_scrolling.tsx
+++ b/src/utils/toggle_scrolling.tsx
@@ -61,4 +61,4 @@ export function disableScrolling(): void {
     document.addEventListener('touchmove', preventDefault, false); // mobile
 }
 
-export default { enable_scrolling, disable_scrolling };
+export default { enableScrolling, disableScrolling };

--- a/src/utils/toggle_scrolling.tsx
+++ b/src/utils/toggle_scrolling.tsx
@@ -1,15 +1,15 @@
 // Adapted from from https://stackoverflow.com/a/4770179
 
 const scrollKeys = [
-    "Space", // space
-    "PageDown", // page up
-    "PageDown", // page down
-    "End", // end
-    "Home", // home
-    "ArrowLeft", // left
-    "ArrowUp", // up
-    "ArrowRight", // right
-    "ArrowDown" // down
+    'Space', // space
+    'PageDown', // page up
+    'PageDown', // page down
+    'End', // end
+    'Home', // home
+    'ArrowLeft', // left
+    'ArrowUp', // up
+    'ArrowRight', // right
+    'ArrowDown' // down
 ];
 
 /**

--- a/src/utils/toggle_scrolling.tsx
+++ b/src/utils/toggle_scrolling.tsx
@@ -1,0 +1,63 @@
+// Adapted from from https://stackoverflow.com/a/4770179
+
+// spacebar: 32, pageup: 33, pagedown: 34, end: 35, home: 36
+// left: 37, up: 38, right: 39, down: 40,
+const scroll_keys = [32,33,34,35,36,37,38,39,40];
+
+/**
+ * Robust way to really block default behavior.
+ * @param e - Event object.
+ */
+function preventDefault(e: any): void {
+    e = e || window.event;
+    if (e.preventDefault) {
+        e.preventDefault();
+    }
+    e.returnValue = false;  
+}
+
+/**
+ * This is a replacement to the build-in 'keydown' handler in the browser.
+ * @param e - Event object.
+ */
+function keydownOverride(e: any): void {
+    for (var i = scroll_keys.length; i--;) {
+        if (e.keyCode === scroll_keys[i]) {
+            preventDefault(e);
+            return;
+        }
+    }
+}
+
+/**
+ * This is a replacement to the build-in 'mousewheel' and 'scroll' handlers in the browser.
+ * @param e - Event object.
+ */
+function wheelOverride(e: any): void {
+    preventDefault(e);
+}
+
+/**
+ * Enable scrolling in the DOM.
+ */
+export function enable_scrolling(): void {
+    if (window.removeEventListener) {
+        window.removeEventListener('DOMMouseScroll', wheelOverride, false);
+    }
+    window.onmousewheel = document.onscroll = document.onkeydown = null;  
+    document.removeEventListener('touchmove', preventDefault, false);
+}
+
+/**
+ * Disable scrolling in the DOM.
+ */
+export function disable_scrolling(): void {
+    if (window.addEventListener) {
+        window.addEventListener('DOMMouseScroll', wheelOverride, false);
+    }
+    window.onmousewheel = document.onscroll = wheelOverride;
+    document.onkeydown = keydownOverride;
+    document.addEventListener('touchmove', preventDefault, false);
+}
+
+export default { enable_scrolling, disable_scrolling };

--- a/src/utils/toggle_scrolling.tsx
+++ b/src/utils/toggle_scrolling.tsx
@@ -9,7 +9,7 @@ const scrollKeys = [
     'ArrowLeft', // left
     'ArrowUp', // up
     'ArrowRight', // right
-    'ArrowDown' // down
+    'ArrowDown', // down
 ];
 
 /**
@@ -27,7 +27,7 @@ export function preventDefault(e: Event): void {
  */
 export function keydownOverride(e: KeyboardEvent): void {
     scrollKeys.forEach((code) => {
-        if (e.code == code) {
+        if (e.code === code) {
             preventDefault(e);
         }
     });

--- a/src/utils/toggle_scrolling.tsx
+++ b/src/utils/toggle_scrolling.tsx
@@ -16,10 +16,8 @@ const scrollKeys = [
  * Robust way to really block default behavior.
  * @param e - Event object.
  */
-function preventDefault(e: any = window.event): void {
-    if (e.preventDefault) {
-        e.preventDefault();
-    }
+export function preventDefault(e: Event): void {
+    e.preventDefault();
     e.returnValue = false;
 }
 
@@ -27,7 +25,7 @@ function preventDefault(e: any = window.event): void {
  * This is a replacement to the build-in 'keydown' handler in the browser.
  * @param e - Event object.
  */
-export function keydownOverride(e: any): void {
+export function keydownOverride(e: KeyboardEvent): void {
     scrollKeys.forEach((code) => {
         if (e.code == code) {
             preventDefault(e);

--- a/src/utils/toggle_scrolling.tsx
+++ b/src/utils/toggle_scrolling.tsx
@@ -2,18 +2,17 @@
 
 // spacebar: 32, pageup: 33, pagedown: 34, end: 35, home: 36
 // left: 37, up: 38, right: 39, down: 40,
-const scroll_keys = [32,33,34,35,36,37,38,39,40];
+const scrollKeys = [32, 33, 34, 35, 36, 37, 38, 39, 40];
 
 /**
  * Robust way to really block default behavior.
  * @param e - Event object.
  */
-function preventDefault(e: any): void {
-    e = e || window.event;
+function preventDefault(e: any = window.event): void {
     if (e.preventDefault) {
         e.preventDefault();
     }
-    e.returnValue = false;  
+    e.returnValue = false;
 }
 
 /**
@@ -21,12 +20,11 @@ function preventDefault(e: any): void {
  * @param e - Event object.
  */
 function keydownOverride(e: any): void {
-    for (var i = scroll_keys.length; i--;) {
-        if (e.keyCode === scroll_keys[i]) {
+    scrollKeys.forEach((code) => {
+        if (e.keyCode === code) {
             preventDefault(e);
-            return;
         }
-    }
+    });
 }
 
 /**
@@ -40,24 +38,27 @@ function wheelOverride(e: any): void {
 /**
  * Enable scrolling in the DOM.
  */
-export function enable_scrolling(): void {
+export function enableScrolling(): void {
     if (window.removeEventListener) {
-        window.removeEventListener('DOMMouseScroll', wheelOverride, false);
+        window.removeEventListener('DOMMouseScroll', wheelOverride, false); // desktop
     }
-    window.onmousewheel = document.onscroll = document.onkeydown = null;  
-    document.removeEventListener('touchmove', preventDefault, false);
+    window.onmousewheel = null;
+    document.onscroll = null;
+    document.onkeydown = null;
+    document.removeEventListener('touchmove', preventDefault, false); // mobile
 }
 
 /**
  * Disable scrolling in the DOM.
  */
-export function disable_scrolling(): void {
+export function disableScrolling(): void {
     if (window.addEventListener) {
-        window.addEventListener('DOMMouseScroll', wheelOverride, false);
+        window.addEventListener('DOMMouseScroll', wheelOverride, false); // desktop
     }
-    window.onmousewheel = document.onscroll = wheelOverride;
+    window.onmousewheel = wheelOverride;
+    document.onscroll = wheelOverride;
     document.onkeydown = keydownOverride;
-    document.addEventListener('touchmove', preventDefault, false);
+    document.addEventListener('touchmove', preventDefault, false); // mobile
 }
 
 export default { enable_scrolling, disable_scrolling };


### PR DESCRIPTION
I've added some utils to actually block mouse scroll input programatically.

Why didn't I do it in CSS?

Because I see doing it in CSS as a hack. What we truly want is to control when to ignore scroll input, namely based on component props. Using a `noscroll` sort of makes it look like that's what's happening, but of course leads to other bugs, such as the fact that the page height is overridden and then scroll bars disappear. Hence: hacky.

So after some research I found this to be the most stable solution which works for desktop and mobile and truly does what we actually want (as I see it).