### PR TITLE
Set auth token within .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,7 @@ publish:
     - yarn build
     - npm --no-git-tag-version version from-git
     - GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i ${CI_PROJECT_DIR}/id_rsa" git push git@github.com:Ultimaker/react-web-components.git HEAD:master
+    - npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
     - npm --unsafe-perm publish
   only:
     - tags

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
This is a better solution because the inclusion of a `.npmrc` file meant adding or removing any packages with yarn threw an error and failed. It's true a dev could just delete that file but they'd have to make sure they never accidentally committed that change, and requiring the deletion of config to run `yarn install` is uncool.