### PR TITLE
Change the logo to text on cloud account login page

### DIFF
--- a/src/components/__tests__/__snapshots__/generic_flow_page.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/generic_flow_page.test.tsx.snap
@@ -1,13 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The GenericFlowPage component should render 1`] = `
+exports[`The GenericFlowPage component should render with an application name "My Account" 1`] = `
 <div
   className="generic-flow-page"
 >
   <div
-    className="generic-flow-page__logo"
+    className="generic-flow-page__header"
   >
-    <UltimakerLogo />
+    <span
+      className="generic-flow-page__um-text"
+    >
+      Ultimaker
+    </span>
+    <span
+      className="generic-flow-page__app__name show-sm"
+    >
+      My Account
+    </span>
+  </div>
+  <div
+    className="generic-flow-page__image"
+  >
+    <img
+      alt="cloud-connecting"
+      className="cloud-connecting-image"
+      src="../../images/cloud_connection/cloud_connecting-image.svg"
+    />
+  </div>
+  <div
+    className="generic-flow-page__title"
+  >
+    Cloud connectivity enabled
+  </div>
+  <div
+    className="generic-flow-page__description"
+  >
+    <p
+      key="0"
+    >
+      Sign in with your Ultimaker account to continue.
+    </p>
+  </div>
+  <div
+    className="generic-flow-page__content"
+  >
+    <Spinner />
+  </div>
+</div>
+`;
+
+exports[`The GenericFlowPage component should render without an application name 1`] = `
+<div
+  className="generic-flow-page"
+>
+  <div
+    className="generic-flow-page__header"
+  >
+    <span
+      className="generic-flow-page__um-text"
+    >
+      Ultimaker
+    </span>
+    <span
+      className="generic-flow-page__app__name show-sm"
+    />
   </div>
   <div
     className="generic-flow-page__image"

--- a/src/components/__tests__/generic_flow_page.test.tsx
+++ b/src/components/__tests__/generic_flow_page.test.tsx
@@ -20,7 +20,13 @@ describe('The GenericFlowPage component', () => {
         wrapper = shallow(<GenericFlowPage {...props} />);
     });
 
-    it('should render', () => {
+    it('should render without an application name', () => {
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render with an application name "My Account"', () => {
+        props.appName = 'My Account'
+        wrapper.setProps(props);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/src/components/generic_flow_page.tsx
+++ b/src/components/generic_flow_page.tsx
@@ -1,9 +1,6 @@
 // Copyright (c) 2018 Ultimaker B.V.
 import * as React from 'react';
 
-// components
-import UltimakerLogo from './icons/ultimaker_logo';
-
 // utils
 import splitTextByNewLine from '../utils/split_text_by_new_line';
 
@@ -12,13 +9,17 @@ export interface GenericFlowPageProps {
     description?: string;
     image?: JSX.Element;
     children?: any;
+    appName?: string;
 }
 
 export const GenericFlowPage: React.StatelessComponent<GenericFlowPageProps> = ({
-    title, description, image, children,
+    title, description, image, children, appName,
 }) => (
     <div className="generic-flow-page">
-        <div className="generic-flow-page__logo"><UltimakerLogo /></div>
+        <div className="generic-flow-page__header">
+            <span className="generic-flow-page__um-text">Ultimaker</span>
+            <span className="generic-flow-page__app__name show-sm">{appName}</span>
+        </div>
         {image
             && <div className="generic-flow-page__image">{image}</div>
         }

--- a/src/stylesheets/_generic_flow_page.scss
+++ b/src/stylesheets/_generic_flow_page.scss
@@ -8,7 +8,7 @@
     }
 }
 
-.generic-flow-page__logo {
+.generic-flow-page__header {
     text-align: center;
     margin-bottom: 2.4rem;
 
@@ -16,10 +16,22 @@
         margin-bottom: 4.8rem;
     }
 
-    > svg {
-        width: 15rem;
-        height: 2.3rem;
+    &:hover, &:focus {
+        text-decoration: none;
     }
+}
+
+.generic-flow-page__um-text {
+    font-size: 2.4rem;
+    font-weight: 500;
+    color: $color-text;
+}
+
+.generic-flow-page__app__name {
+    font-size: 2.4rem;
+    font-weight: 300;
+    margin-left: 0.6rem;
+    color: $color-text;
 }
 
 .generic-flow-page__image {


### PR DESCRIPTION
Update the React component 'GenericFlowPage' to change the logo to text on cloud account login page.

Style references: [component](https://github.com/Ultimaker/react-web-components/blob/master/src/components/header.tsx#L87) and [css](https://github.com/Ultimaker/react-web-components/blob/a3bacdf8ba6e7f8b4fd029f7db3a92b4d7af1186/src/stylesheets/_header.scss#L35).