### PR TITLE
Update `<BoxPlaceholder />`: allow choosing background colours

### DIFF
--- a/src/components/__tests__/__snapshots__/box_placeholder.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/box_placeholder.test.tsx.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The BoxPlaceholder component should render with className "background--grey" 1`] = `
-<div
-  className="box-placeholder background--grey"
-  style={
-    Object {
-      "height": "10rem",
-      "width": "10rem",
-    }
-  }
->
-  <Icon(BoxIcon) />
-</div>
-`;
-
 exports[`The BoxPlaceholder component should render with className "background--transparent" 1`] = `
 <div
   className="box-placeholder background--transparent"

--- a/src/components/__tests__/__snapshots__/box_placeholder.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/box_placeholder.test.tsx.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The BoxPlaceholder component should render 1`] = `
-<div
-  className="box-placeholder"
-  style={
-    Object {
-      "height": "10rem",
-      "width": "10rem",
-    }
-  }
->
-  <Icon(BoxIcon) />
-</div>
-`;
-
 exports[`The BoxPlaceholder component should render with className "background--grey" 1`] = `
 <div
   className="box-placeholder background--grey"

--- a/src/components/__tests__/__snapshots__/box_placeholder.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/box_placeholder.test.tsx.snap
@@ -13,3 +13,31 @@ exports[`The BoxPlaceholder component should render 1`] = `
   <Icon(BoxIcon) />
 </div>
 `;
+
+exports[`The BoxPlaceholder component should render with className "background--grey" 1`] = `
+<div
+  className="box-placeholder background--grey"
+  style={
+    Object {
+      "height": "10rem",
+      "width": "10rem",
+    }
+  }
+>
+  <Icon(BoxIcon) />
+</div>
+`;
+
+exports[`The BoxPlaceholder component should render with className "background--transparent" 1`] = `
+<div
+  className="box-placeholder background--transparent"
+  style={
+    Object {
+      "height": "10rem",
+      "width": "10rem",
+    }
+  }
+>
+  <Icon(BoxIcon) />
+</div>
+`;

--- a/src/components/__tests__/box_placeholder.test.tsx
+++ b/src/components/__tests__/box_placeholder.test.tsx
@@ -20,9 +20,9 @@ describe('The BoxPlaceholder component', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render with className "background--grey"', () => {
-        props.backgroundColor = 'grey';
+    it('should render with className "background--light"', () => {
+        props.backgroundColor = 'light';
         wrapper.setProps(props);
-        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.hasClass('background--light')).toBe(true);
     });
 });

--- a/src/components/__tests__/box_placeholder.test.tsx
+++ b/src/components/__tests__/box_placeholder.test.tsx
@@ -16,7 +16,13 @@ describe('The BoxPlaceholder component', () => {
         wrapper = shallow(<BoxPlaceholder {...props} />);
     });
 
-    it('should render', () => {
+    it('should render with className "background--transparent"', () => {
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render with className "background--grey"', () => {
+        props.backgroundColor = 'grey'
+        wrapper.setProps(props);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/src/components/__tests__/box_placeholder.test.tsx
+++ b/src/components/__tests__/box_placeholder.test.tsx
@@ -21,7 +21,7 @@ describe('The BoxPlaceholder component', () => {
     });
 
     it('should render with className "background--grey"', () => {
-        props.backgroundColor = 'grey'
+        props.backgroundColor = 'grey';
         wrapper.setProps(props);
         expect(wrapper).toMatchSnapshot();
     });

--- a/src/components/box_placeholder.tsx
+++ b/src/components/box_placeholder.tsx
@@ -2,20 +2,30 @@ import * as React from 'react';
 
 import BoxIcon from './icons/box_icon';
 
+export type BoxPlaceholderBackground = 'grey' | 'transparent';
+
 export interface BoxPlaceholderProps {
     /** Size of the placeholder. Include unit */
     size: string;
+    /** Background color */
+    backgroundColor?: BoxPlaceholderBackground;
 }
 
 
-export const BoxPlaceholder: React.StatelessComponent<BoxPlaceholderProps> = ({ size }) => (
+export const BoxPlaceholder: React.StatelessComponent<BoxPlaceholderProps> = ({
+    size, backgroundColor,
+}) => (
     <div
-        className="box-placeholder"
+        className={`box-placeholder background--${backgroundColor}`}
         style={{ height: size, width: size }}
     >
         <BoxIcon />
     </div>
 );
+
+BoxPlaceholder.defaultProps = {
+    backgroundColor: 'transparent',
+};
 
 BoxPlaceholder.displayName = 'BoxPlaceholder';
 

--- a/src/components/box_placeholder.tsx
+++ b/src/components/box_placeholder.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import BoxIcon from './icons/box_icon';
 
-export type BoxPlaceholderBackground = 'grey' | 'transparent';
+export type BoxPlaceholderBackground = 'light' | 'transparent';
 
 export interface BoxPlaceholderProps {
     /** Size of the placeholder. Include unit */

--- a/src/stylesheets/_box_placeholder.scss
+++ b/src/stylesheets/_box_placeholder.scss
@@ -1,8 +1,11 @@
 .box-placeholder {
-    background-color: $color-transparent-grey-light;
     display: flex;
     justify-content: center;
     align-items: center;
+
+    &.background--grey {
+        background-color: $color-transparent-grey-light;
+    }
 
     .icon--box {
         width: 50%;

--- a/src/stylesheets/_box_placeholder.scss
+++ b/src/stylesheets/_box_placeholder.scss
@@ -3,7 +3,7 @@
     justify-content: center;
     align-items: center;
 
-    &.background--grey {
+    &.background--light {
         background-color: $color-transparent-grey-light;
     }
 


### PR DESCRIPTION
* According to [this requirement](https://jira.ultimaker.com/browse/CS-256?focusedCommentId=90624&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-90624) and [this requirement](https://jira.ultimaker.com/browse/CS-256?focusedCommentId=90624&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-90624) the box placeholder can be grey or white (transparent); adding the functionality to enable it. Default: transparent.