### PR TITLE
Allow `<ImageUpload />` and `<ImageUploadField />` accept placeholderType

### DIFF
--- a/src/components/__tests__/image_upload.test.tsx
+++ b/src/components/__tests__/image_upload.test.tsx
@@ -5,6 +5,8 @@ import { shallow, render } from 'enzyme';
 // component
 import ImageUpload from '../image_upload';
 import ImageCropper from '../image_cropper';
+import ProfileImage from '../profile_image';
+import BoxPlaceholder from '../box_placeholder';
 
 let Dropzone = require('react-dropzone');
 
@@ -86,6 +88,20 @@ describe('The image upload component', () => {
         expect(wrapper.find('.cover')).toHaveLength(1);
     });
 
+    it('should render a person placeholder', () => {
+        wrapper.setProps({
+            placeholderType: 'person',
+        });
+        expect(wrapper.find(ProfileImage)).toHaveLength(1);
+    });
+
+    it('should render a box placeholder', () => {
+        wrapper.setProps({
+            placeholderType: 'other',
+        });
+        expect(wrapper.find(BoxPlaceholder)).toHaveLength(1);
+    });
+
     it('should ignore empty callbacks', () => {
         wrapper.setProps({ onFileSelection: null, onFileRead: null });
         wrapper.find(Dropzone).prop('onDrop')([image]);
@@ -114,6 +130,5 @@ describe('The image upload component', () => {
         expect(wrapper.find(Dropzone)).toHaveLength(1);
         expect(wrapper.find(ImageCropper)).toHaveLength(0);
         wrapper.find(Dropzone).prop('onDrop')([image]);
-
     });
 });

--- a/src/components/image_upload.tsx
+++ b/src/components/image_upload.tsx
@@ -5,6 +5,8 @@ import classNames from 'classnames';
 import { Image, ImageShape } from './image';
 import UploadIcon from './icons/upload_icon';
 import ImageCropper from './image_cropper';
+import ProfileImage from './profile_image';
+import BoxPlaceholder from './box_placeholder';
 
 // dependencies
 let Dropzone = require('react-dropzone');
@@ -13,6 +15,8 @@ if ('default' in Dropzone) {
     /* istanbul ignore next */ // ignores coverage for this line.
     Dropzone = Dropzone.default;
 }
+
+export type ImagePlaceholderType = 'person' | 'other';
 
 /**
  * This interface adds an image preview URL to blob files.
@@ -38,6 +42,8 @@ export interface ImageUploadProps {
     imageURL?: string;
     /** Placeholder label */
     placeholderLabel?: string;
+    /** Placeholder type: 'person' | 'other' */
+    placeholderType?: ImagePlaceholderType;
     /** The maximum amount of megabytes allowed to be uploaded */
     maxMb?: number;
     /**
@@ -151,6 +157,19 @@ export class ImageUpload extends React.Component<ImageUploadProps, ImageUploadSt
         );
     }
 
+    private _renderPlaceholder(): JSX.Element {
+        const { size, shape, placeholderType } = this.props;
+
+        switch (placeholderType) {
+        case 'person':
+            return <ProfileImage size={size} />;
+        case 'other':
+            return <BoxPlaceholder backgroundColor="light" size={size} />;
+        default:
+            return <div className={`placeholder placeholder--${shape}`} />;
+        }
+    }
+
     private _renderDropzone(): JSX.Element {
         const {
             size, shape, imageURL, placeholderLabel,
@@ -191,7 +210,7 @@ export class ImageUpload extends React.Component<ImageUploadProps, ImageUploadSt
                 </Dropzone>
                 {imageURL
                     ? <Image src={imageURL} shape={shape} size={size} />
-                    : <div className={`placeholder placeholder--${shape}`} />
+                    : this._renderPlaceholder()
                 }
             </div>
         );

--- a/src/components/image_upload.tsx
+++ b/src/components/image_upload.tsx
@@ -172,11 +172,14 @@ export class ImageUpload extends React.Component<ImageUploadProps, ImageUploadSt
 
     private _renderDropzone(): JSX.Element {
         const {
-            size, shape, imageURL, placeholderLabel,
+            size, shape, imageURL, placeholderLabel, placeholderType,
         } = this.props;
         const { dropActive, dropFocus } = this.state;
 
-        const iconClasses = classNames({ hide: imageURL !== null, 'icon-with-label': placeholderLabel });
+        const iconClasses = classNames({
+            hide: imageURL !== null || placeholderType !== undefined,
+            'icon-with-label': placeholderLabel,
+        });
         const hoverAreaClasses = classNames('hover-area', { show: dropActive || dropFocus });
 
         return (

--- a/src/components/input_fields/image_upload_field.tsx
+++ b/src/components/input_fields/image_upload_field.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 
 import InputFieldWrapper, { InputFieldProps } from './input_field_wrapper';
-import ImageUpload, { ImageFile } from '../image_upload';
+import ImageUpload, { ImageFile, ImagePlaceholderType } from '../image_upload';
 import { Image, ImageShape } from '../image';
 
 
@@ -33,6 +33,9 @@ export interface ImageUploadFieldProps extends InputFieldProps {
 
     /** The maximum amount of megabytes allowed to be uploaded */
     maxMb?: number;
+
+    /** Placeholder type: 'person' | 'other' */
+    placeholderType?: ImagePlaceholderType;
 }
 
 /**
@@ -78,7 +81,7 @@ export class ImageUploadField extends React.Component
     render() {
         const {
             imageSize, imageShape, placeholder, value, onReadHandler,
-            children, allowCropping, maxMb, ...wrapperProps
+            children, allowCropping, maxMb, placeholderType, ...wrapperProps
         } = this.props;
         const { id, staticField } = wrapperProps;
         const { touched } = this.state;
@@ -97,6 +100,7 @@ export class ImageUploadField extends React.Component
                                 onFileRead={contents => this._onFileRead(contents)}
                                 shape={imageShape}
                                 placeholderLabel={placeholder}
+                                placeholderType={placeholderType}
                                 allowCropping={allowCropping}
                             />
                         )


### PR DESCRIPTION
This PR aims enabling the rendering of a placeholder for an image upload field.

The background of the upload field is grey. Hide `<UploadIcon />` (the "upload cloud") when there's a placeholder (the upload icon is only shown when the cursor is hover on the placeholder).

By default (when the developer haven't specify anything for `<ImageUploadField />`) it will be a `<div>` displaying a square or round box, depending on the `shape` parameter.

For person the shape is round, and for others (material, plug-in etc.) the shape is square.

See [CS-256](https://jira.ultimaker.com/browse/CS-256) for details.

Preview:
1. Default
![placeholder_default](https://user-images.githubusercontent.com/1527106/65253607-3279cb80-dafb-11e9-8ac1-89ebdd3c28e7.png)

2. Person
![placeholder_person](https://user-images.githubusercontent.com/1527106/65253643-41f91480-dafb-11e9-9a1c-bebeb61ec583.png)

3. Other
![placeholder_other](https://user-images.githubusercontent.com/1527106/65253653-49202280-dafb-11e9-9dcd-1a8fa1ded740.png)