### PR TITLE
CS-256 fix: Display the placeholder for `staticField` when there's no user-uploaded image

### DIFF
--- a/src/components/input_fields/__tests__/image_upload_field.test.tsx
+++ b/src/components/input_fields/__tests__/image_upload_field.test.tsx
@@ -7,6 +7,7 @@ import ImageUploadField, { ImageUploadFieldProps } from '../image_upload_field';
 import InputFieldWrapper from '../input_field_wrapper';
 import ImageUpload from '../../image_upload';
 import { Image } from '../../image';
+import BoxPlaceholder from '../../box_placeholder';
 
 describe('The image upload field component', () => {
     let props: ImageUploadFieldProps;
@@ -38,6 +39,18 @@ describe('The image upload field component', () => {
         expect(wrapper.find(ImageUpload)).toHaveLength(0);
         expect(wrapper.find(Image).props()).toEqual({
             src: props.value, size: props.imageSize, shape: props.imageShape,
+        });
+    });
+
+    it('should render a placeholder', () => {
+        wrapper.setProps({
+            staticField: true,
+            value: null,
+        });
+        expect(wrapper.find(Image)).toHaveLength(0);
+        expect(wrapper.find(ImageUpload)).toHaveLength(0);
+        expect(wrapper.find(BoxPlaceholder).props()).toEqual({
+            size: props.imageSize,
         });
     });
 

--- a/src/components/input_fields/__tests__/image_upload_field.test.tsx
+++ b/src/components/input_fields/__tests__/image_upload_field.test.tsx
@@ -50,6 +50,7 @@ describe('The image upload field component', () => {
         expect(wrapper.find(Image)).toHaveLength(0);
         expect(wrapper.find(ImageUpload)).toHaveLength(0);
         expect(wrapper.find(BoxPlaceholder).props()).toEqual({
+            backgroundColor: 'transparent',
             size: props.imageSize,
         });
     });

--- a/src/components/input_fields/__tests__/image_upload_field.test.tsx
+++ b/src/components/input_fields/__tests__/image_upload_field.test.tsx
@@ -8,6 +8,7 @@ import InputFieldWrapper from '../input_field_wrapper';
 import ImageUpload from '../../image_upload';
 import { Image } from '../../image';
 import BoxPlaceholder from '../../box_placeholder';
+import ProfileImage from '../../profile_image';
 
 describe('The image upload field component', () => {
     let props: ImageUploadFieldProps;
@@ -25,6 +26,7 @@ describe('The image upload field component', () => {
             imageShape: 'round',
             value: 'http://image.ultimaker.com',
             placeholder: 'A placeholder text',
+            placeholderType: undefined,
         };
         wrapper = shallow(<ImageUploadField {...props} />);
     });
@@ -42,17 +44,27 @@ describe('The image upload field component', () => {
         });
     });
 
-    it('should render a placeholder', () => {
+    it('should render a box placeholder', () => {
         wrapper.setProps({
             staticField: true,
             value: null,
         });
         expect(wrapper.find(Image)).toHaveLength(0);
         expect(wrapper.find(ImageUpload)).toHaveLength(0);
-        expect(wrapper.find(BoxPlaceholder).props()).toEqual({
-            backgroundColor: 'transparent',
-            size: props.imageSize,
+        expect(wrapper.find(ProfileImage)).toHaveLength(0);
+        expect(wrapper.find(BoxPlaceholder)).toHaveLength(1);
+    });
+
+    it('should render a person placeholder', () => {
+        wrapper.setProps({
+            staticField: true,
+            value: null,
+            placeholderType: 'person',
         });
+        expect(wrapper.find(Image)).toHaveLength(0);
+        expect(wrapper.find(ImageUpload)).toHaveLength(0);
+        expect(wrapper.find(BoxPlaceholder)).toHaveLength(0);
+        expect(wrapper.find(ProfileImage)).toHaveLength(1);
     });
 
     it('should render a image upload', () => {

--- a/src/components/input_fields/image_upload_field.tsx
+++ b/src/components/input_fields/image_upload_field.tsx
@@ -5,7 +5,7 @@ import InputFieldWrapper, { InputFieldProps } from './input_field_wrapper';
 import ImageUpload, { ImageFile, ImagePlaceholderType } from '../image_upload';
 import { Image, ImageShape } from '../image';
 import { BoxPlaceholder } from '../box_placeholder';
-import ProfileImage from 'components/profile_image';
+import { ProfileImage } from '../profile_image';
 
 
 /**

--- a/src/components/input_fields/image_upload_field.tsx
+++ b/src/components/input_fields/image_upload_field.tsx
@@ -85,10 +85,10 @@ export class ImageUploadField extends React.Component
         } = this.props;
 
         if (value) {
-            return <Image src={value} size={imageSize} shape={imageShape} />
+            return <Image src={value} size={imageSize} shape={imageShape} />;
         }
 
-        return <BoxPlaceholder size={imageSize} />
+        return <BoxPlaceholder size={imageSize} />;
     }
 
     render() {

--- a/src/components/input_fields/image_upload_field.tsx
+++ b/src/components/input_fields/image_upload_field.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import InputFieldWrapper, { InputFieldProps } from './input_field_wrapper';
 import ImageUpload, { ImageFile, ImagePlaceholderType } from '../image_upload';
 import { Image, ImageShape } from '../image';
+import { BoxPlaceholder } from '../box_placeholder';
 
 
 /**
@@ -78,6 +79,18 @@ export class ImageUploadField extends React.Component
         }
     }
 
+    private _renderImageOrPlaceholder(): JSX.Element {
+        const {
+            value, imageSize, imageShape
+        } = this.props;
+
+        if (value) {
+            return <Image src={value} size={imageSize} shape={imageShape} />
+        }
+
+        return <BoxPlaceholder size={imageSize} />
+    }
+
     render() {
         const {
             imageSize, imageShape, placeholder, value, onReadHandler,
@@ -89,7 +102,7 @@ export class ImageUploadField extends React.Component
             <InputFieldWrapper touched={touched} inputChildren={children} {...wrapperProps}>
                 {
                     staticField
-                        ? <Image src={value} size={imageSize} shape={imageShape} />
+                        ? this._renderImageOrPlaceholder()
                         : (
                             <ImageUpload
                                 id={id}

--- a/src/components/input_fields/image_upload_field.tsx
+++ b/src/components/input_fields/image_upload_field.tsx
@@ -5,6 +5,7 @@ import InputFieldWrapper, { InputFieldProps } from './input_field_wrapper';
 import ImageUpload, { ImageFile, ImagePlaceholderType } from '../image_upload';
 import { Image, ImageShape } from '../image';
 import { BoxPlaceholder } from '../box_placeholder';
+import ProfileImage from 'components/profile_image';
 
 
 /**
@@ -81,11 +82,15 @@ export class ImageUploadField extends React.Component
 
     private _renderImageOrPlaceholder(): JSX.Element {
         const {
-            value, imageSize, imageShape
+            value, imageSize, imageShape, placeholderType,
         } = this.props;
 
         if (value) {
             return <Image src={value} size={imageSize} shape={imageShape} />;
+        }
+
+        if (placeholderType === 'person') {
+            return <ProfileImage size={imageSize} />;
         }
 
         return <BoxPlaceholder size={imageSize} />;


### PR DESCRIPTION
Upon the QA of CS-256, [Meike discovered that](https://jira.ultimaker.com/browse/CS-256?focusedCommentId=91185&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-91185) the placeholder of the "release details" page cannot be displayed, if the user saves a draft without uploading an image.

The issue is because of the use of `staticField` in `<ImageUploadField />`. This PR adds a method for this component, allowing the rendering of a placeholder (`person` or `other`), if there's no imageURL specified.

Preview:
![Screenshot 2019-09-26 at 14 12 04](https://user-images.githubusercontent.com/1527106/65687401-9e16e800-e069-11e9-8037-9c27c496661c.png)
