### PR TITLE
Move css-loader dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5967,20 +5967,85 @@
             }
         },
         "css-loader": {
-            "version": "2.1.0",
-            "resolved": "https://registry.yarnpkg.com/css-loader/-/css-loader-2.1.0.tgz",
-            "integrity": "sha1-QpUqwivKXQdpeGOOmBOrzkm48Mw=",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.2.0.tgz",
+            "integrity": "sha512-QTF3Ud5H7DaZotgdcJjGMvyDj5F3Pn1j/sC6VBEOVp94cbwqyIBdcs/quzj4MC1BKQSrTpQznegH/5giYbhnCQ==",
+            "dev": true,
             "requires": {
-                "icss-utils": "^4.0.0",
-                "loader-utils": "^1.2.1",
-                "lodash": "^4.17.11",
-                "postcss": "^7.0.6",
+                "camelcase": "^5.3.1",
+                "cssesc": "^3.0.0",
+                "icss-utils": "^4.1.1",
+                "loader-utils": "^1.2.3",
+                "normalize-path": "^3.0.0",
+                "postcss": "^7.0.17",
                 "postcss-modules-extract-imports": "^2.0.0",
-                "postcss-modules-local-by-default": "^2.0.3",
-                "postcss-modules-scope": "^2.0.0",
-                "postcss-modules-values": "^2.0.0",
-                "postcss-value-parser": "^3.3.0",
-                "schema-utils": "^1.0.0"
+                "postcss-modules-local-by-default": "^3.0.2",
+                "postcss-modules-scope": "^2.1.0",
+                "postcss-modules-values": "^3.0.0",
+                "postcss-value-parser": "^4.0.0",
+                "schema-utils": "^2.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.10.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+                    "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ajv-keywords": {
+                    "version": "3.4.1",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+                    "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+                    "dev": true
+                },
+                "cssesc": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+                    "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "7.0.20",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+                    "integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^6.1.0"
+                    }
+                },
+                "postcss-value-parser": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+                    "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+                    "dev": true
+                },
+                "schema-utils": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.5.0.tgz",
+                    "integrity": "sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.10.2",
+                        "ajv-keywords": "^3.4.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "css-select": {
@@ -6023,6 +6088,7 @@
             "version": "0.7.1",
             "resolved": "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
             "integrity": "sha1-oXcnGovKUBkXL0+JH8bu2cv2jV0=",
+            "dev": true,
             "requires": {
                 "cssesc": "^0.1.0",
                 "fastparse": "^1.1.1",
@@ -6033,6 +6099,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-1.0.0.tgz",
                     "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+                    "dev": true,
                     "requires": {
                         "regenerate": "^1.2.1",
                         "regjsgen": "^0.2.0",
@@ -6042,12 +6109,14 @@
                 "regjsgen": {
                     "version": "0.2.0",
                     "resolved": "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz",
-                    "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+                    "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+                    "dev": true
                 },
                 "regjsparser": {
                     "version": "0.1.5",
                     "resolved": "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz",
                     "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+                    "dev": true,
                     "requires": {
                         "jsesc": "~0.5.0"
                     }
@@ -6087,7 +6156,8 @@
         "cssesc": {
             "version": "0.1.0",
             "resolved": "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz",
-            "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
+            "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+            "dev": true
         },
         "csso": {
             "version": "3.5.1",
@@ -7485,7 +7555,8 @@
         "fastparse": {
             "version": "1.1.2",
             "resolved": "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz",
-            "integrity": "sha1-kXKMWllC7O2FMSg8eUQe5BIsNak="
+            "integrity": "sha1-kXKMWllC7O2FMSg8eUQe5BIsNak=",
+            "dev": true
         },
         "faye-websocket": {
             "version": "0.11.1",
@@ -8983,12 +9054,14 @@
         "icss-replace-symbols": {
             "version": "1.1.0",
             "resolved": "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-            "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
+            "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+            "dev": true
         },
         "icss-utils": {
-            "version": "4.1.0",
-            "resolved": "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.0.tgz",
-            "integrity": "sha1-M527/7n4cpokO3AeHCnUzFjFLw4=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+            "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
+            "dev": true,
             "requires": {
                 "postcss": "^7.0.14"
             }
@@ -10273,7 +10346,8 @@
         "jsesc": {
             "version": "0.5.0",
             "resolved": "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz",
-            "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+            "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
@@ -12209,6 +12283,7 @@
             "version": "7.0.14",
             "resolved": "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz",
             "integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
+            "dev": true,
             "requires": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -12219,6 +12294,7 @@
                     "version": "6.1.0",
                     "resolved": "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz",
                     "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+                    "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
                     }
@@ -12315,37 +12391,106 @@
         },
         "postcss-modules-extract-imports": {
             "version": "2.0.0",
-            "resolved": "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
-            "integrity": "sha1-gYcZoa4doyX5gyRGsBE27rSTzX4=",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+            "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+            "dev": true,
             "requires": {
                 "postcss": "^7.0.5"
             }
         },
         "postcss-modules-local-by-default": {
-            "version": "2.0.5",
-            "resolved": "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.5.tgz",
-            "integrity": "sha1-fzh/aPVVVZgGjk1tHqC31vqYQnI=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
+            "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
+            "dev": true,
             "requires": {
-                "css-selector-tokenizer": "^0.7.0",
-                "postcss": "^7.0.6",
-                "postcss-value-parser": "^3.3.1"
+                "icss-utils": "^4.1.1",
+                "postcss": "^7.0.16",
+                "postcss-selector-parser": "^6.0.2",
+                "postcss-value-parser": "^4.0.0"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+                    "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "7.0.20",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.20.tgz",
+                    "integrity": "sha512-VOdO3a5nHVftPSEbG1zaG320b4mH5KAflH+pIeVAF5/hlw6YumELSgHZQBekjg29Oj4qw7XAyp9tIEBpeNWcyg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^6.1.0"
+                    }
+                },
+                "postcss-selector-parser": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+                    "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
+                    }
+                },
+                "postcss-value-parser": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+                    "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "postcss-modules-scope": {
-            "version": "2.0.1",
-            "resolved": "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-2.0.1.tgz",
-            "integrity": "sha1-LA8jlM3kzQkUfbBUxokX449tQ6Q=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
+            "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
+            "dev": true,
             "requires": {
-                "css-selector-tokenizer": "^0.7.0",
-                "postcss": "^7.0.6"
+                "postcss": "^7.0.6",
+                "postcss-selector-parser": "^6.0.0"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+                    "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+                    "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
+                    }
+                }
             }
         },
         "postcss-modules-values": {
-            "version": "2.0.0",
-            "resolved": "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
-            "integrity": "sha1-R5tG3Axco9x/pScIUYNrnscVL2Q=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+            "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+            "dev": true,
             "requires": {
-                "icss-replace-symbols": "^1.1.0",
+                "icss-utils": "^4.0.0",
                 "postcss": "^7.0.6"
             }
         },
@@ -12415,7 +12560,8 @@
         "postcss-value-parser": {
             "version": "3.3.1",
             "resolved": "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-            "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+            "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+            "dev": true
         },
         "prelude-ls": {
             "version": "1.1.2",
@@ -13497,7 +13643,8 @@
         "regenerate": {
             "version": "1.4.0",
             "resolved": "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz",
-            "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE="
+            "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
+            "dev": true
         },
         "regenerate-unicode-properties": {
             "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "homepage": "https://github.com/Ultimaker/react-web-components#readme",
     "dependencies": {
         "classnames": "^2.2.6",
-        "css-loader": "^2.1.0",
         "eslint-plugin-react-hooks": "^1.7.0",
         "gettext-parser": "^3.1.0",
         "lodash.debounce": "^4.0.8",
@@ -81,6 +80,7 @@
         "awesome-typescript-loader": "^5.2.1",
         "babel-loader": "^8.0.5",
         "copyfiles": "^2.1.0",
+        "css-loader": "^3.2.0",
         "enzyme": "3.9.0",
         "enzyme-adapter-react-16": "^1.9.1",
         "enzyme-to-json": "^3.3.4",


### PR DESCRIPTION
stardust-mycloud complained that webpack should be installed manually
because it was a peerDependency for css-loader.

stardust-mycloud uses parcel instead of webpack so this requirement
seems to make no sense.

'npm ls css-loader' showed that react-web-components was the culprit.