### PR TITLE
Clean up tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,31 +1,25 @@
 {
     "compilerOptions": {
-        "declaration": true,
-        "sourceMap": true,
-        "target": "es5",
-        "module": "commonjs",
-        "noImplicitAny": false,
-        "outDir": "dist",
-        "jsx": "react",
-        "lib": [
-            "es6",
-            "dom"
-        ],
-        "rootDirs": [
-            "src"
-        ],
+        "allowUnreachableCode": false,
+        "allowUnusedLabels": false,
         "baseUrl": "src",
-        "allowJs": false
+        "declaration": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
+        "module": "commonjs",
+        "noEmitOnError": true,
+        "outDir": "dist",
+        "strictBindCallApply": true,
+        "sourceMap": true,
+        "target": "es5"
     },
     "include": [
         "src/**/*"
     ],
     "exclude": [
         "node_modules",
-        "build",
-        "scripts",
-        "src/**/*.test.tsx",
-        "src/__mocks__/**/*",
-        "src/stories/**/*"
+        "**/__tests__",
+        "**/__mocks__",
+        "**/stories"
     ]
 }


### PR DESCRIPTION
Remove unnecessary compiler options and clean up exclude patterns.

Slightly increase strictness.

Order `compilerOptions` alphabetically.