### PR TITLE
Refactor Pill component

### DIFF
--- a/src/components/__tests__/__snapshots__/pill.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/pill.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The Pill component should render 1`] = `
-<div
+<span
   className="pill"
 />
 `;

--- a/src/components/pill.tsx
+++ b/src/components/pill.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+const PILL_CLASSNAME = 'pill';
+const PILL_CLASSNAME_ACTIVE = 'pill--active';
+
 export interface PillProps {
-    /** Whether the pill should be shown as active */
     active?: boolean
 }
 
-export const Pill: React.StatelessComponent<PillProps> = ({ active, children }) => {
-    const classes = classNames('pill', { active });
+export const Pill: React.FC<PillProps> = ({ active, children }) => {
+    const classes = classNames(PILL_CLASSNAME, {
+        [PILL_CLASSNAME_ACTIVE]: active,
+    });
 
-    return <div className={classes}>{children}</div>;
+    return <span className={classes}>{children}</span>;
 };
 
 Pill.defaultProps = {

--- a/src/stylesheets/_pill.scss
+++ b/src/stylesheets/_pill.scss
@@ -1,15 +1,14 @@
 .pill {
-    padding: 0 1.2rem;
-    color: $color-text-light;
-
-    @include font-size-text-3;
-    border-radius: 9999px;
-    line-height: 2.6rem;
-    background-color: $pill-color-background;
+    background-color: $color-grey-lighter;
+    border-radius: 1.3rem;
+    color: $color-grey-darker;
     display: inline-block;
+    font-size: 1.2rem;
+    line-height: 2.6rem;
+    padding: 0 1.2rem;
+}
 
-    &.active {
-        color: $color-white;
-        background-color: $pill-color-background-active;
-    }
+.pill--active {
+    background-color: $color-blue;
+    color: $color-white;
 }


### PR DESCRIPTION
This is a tiny example in which I've "refactored" the Pill component and introduced a few new patterns.

- Use BEM class selectors
- Avoid nesting in Sass
- Use consts for class selectors in the `.tsx` files and declare them at the top of the file
- Remove comments that only take up space but add nothing that is not already clear from the file itself
- Use `React.FC<Props>` instead of the deprecated `React.StatelessComponent<Props>`