### PR TITLE
CS-466 fix unintended keys closing dropdowns

### DIFF
--- a/src/components/__tests__/drop_down_menu_base.test.tsx
+++ b/src/components/__tests__/drop_down_menu_base.test.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) 2018 Ultimaker B.V.
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount, ShallowWrapper } from 'enzyme';
 
 // component
 import { DropDownMenuBase, DropDownMenuBaseProps } from '../drop_down_menu_base';
 import DropDownMenuItem from '../drop_down_menu_item';
+import Button from '../button';
 
 // mocks
 import { mockClickEvent } from '../../__mocks__/clickMock';
@@ -29,18 +30,18 @@ describe('The DropDownMenuBase component', () => {
     });
 
     it('should call toggle menu handler when the trigger is clicked', () => {
-        wrapper.find('.drop-down-menu-base__trigger').props().onClickHandler();
+        wrapper.find(Button).props().onClickHandler();
         expect(props.onToggleMenuHandler).toBeCalledWith(true);
     });
 
     it('should call toggle menu handler when the trigger is clicked', () => {
         // open menu
-        wrapper.find('.drop-down-menu-base__trigger').props().onClickHandler();
+        wrapper.find(Button).props().onClickHandler();
         expect(props.onToggleMenuHandler).toBeCalledWith(true);
 
         // close menu
         wrapper.setProps({ showMenu: true });
-        wrapper.find('.drop-down-menu-base__trigger').props().onClickHandler();
+        wrapper.find(Button).props().onClickHandler();
         expect(props.onToggleMenuHandler).toBeCalledWith(false);
     });
 
@@ -66,7 +67,8 @@ describe('The DropDownMenuBase component', () => {
     });
 
     it('should call toggle menu handler when escape is pressed', () => {
-        wrapper.instance()._onOutsideFocusHandler({ key: 'Escape' });
+        // TODO this needs a better way to test, along with the click event, as right now it is not meaningful.
+        wrapper.instance()._keyPressHandler({ key: 'Escape' });
         expect(props.onToggleMenuHandler).toBeCalledWith(false);
     });
 });

--- a/src/components/__tests__/drop_down_menu_base.test.tsx
+++ b/src/components/__tests__/drop_down_menu_base.test.tsx
@@ -67,7 +67,9 @@ describe('The DropDownMenuBase component', () => {
     });
 
     it('should call toggle menu handler when escape is pressed', () => {
-        // TODO this needs a better way to test, along with the click event, as right now it is not meaningful.
+        // TODO This test is now calling a private method of the component.
+        // If the correct type is added to the wrapper, this will not be possible.
+        // It is also not actually testing the functionality. Tests like this need to be revised.
         wrapper.instance()._keyPressHandler({ key: 'Escape' });
         expect(props.onToggleMenuHandler).toBeCalledWith(false);
     });

--- a/src/components/__tests__/drop_down_menu_base.test.tsx
+++ b/src/components/__tests__/drop_down_menu_base.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2018 Ultimaker B.V.
 import * as React from 'react';
-import { shallow, mount, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 
 // component
 import { DropDownMenuBase, DropDownMenuBaseProps } from '../drop_down_menu_base';

--- a/src/components/drop_down_menu_base.tsx
+++ b/src/components/drop_down_menu_base.tsx
@@ -44,7 +44,7 @@ export class DropDownMenuBase extends React.Component<DropDownMenuBaseProps, {}>
         this._keyPressHandler = this._keyPressHandler.bind(this);
     }
 
-    private _onAnywhereClickHandler(event): void {
+    private _onAnywhereClickHandler(event:MouseEvent): void {
         /* istanbul ignore next */
         if (this._menuRef
             && this._menuRef.current
@@ -53,7 +53,7 @@ export class DropDownMenuBase extends React.Component<DropDownMenuBaseProps, {}>
         }
     }
 
-    private _keyPressHandler(event): void {
+    private _keyPressHandler(event:KeyboardEvent): void {
         /* istanbul ignore next */
         if (event.key === 'Escape') {
             this._onToggleMenuHandler(false);

--- a/src/components/drop_down_menu_base.tsx
+++ b/src/components/drop_down_menu_base.tsx
@@ -39,20 +39,23 @@ export class DropDownMenuBase extends React.Component<DropDownMenuBaseProps, {}>
     constructor(props: DropDownMenuBaseProps) {
         super(props);
         this._menuRef = React.createRef();
-        this._onOutsideFocusHandler = this._onOutsideFocusHandler.bind(this);
+        this._onAnywhereClickHandler = this._onAnywhereClickHandler.bind(this);
         this._onToggleMenuHandler = this._onToggleMenuHandler.bind(this);
+        this._keyPressHandler = this._keyPressHandler.bind(this);
     }
 
-    private _onOutsideFocusHandler(event): void {
+    private _onAnywhereClickHandler(event): void {
         /* istanbul ignore next */
         if (this._menuRef
             && this._menuRef.current
             && !this._menuRef.current.contains(event.target)) {
             this._onToggleMenuHandler(false);
         }
+    }
 
+    private _keyPressHandler(event): void {
+        /* istanbul ignore next */
         if (event.key === 'Escape') {
-            // close menu is user presses escape
             this._onToggleMenuHandler(false);
         }
     }
@@ -63,11 +66,11 @@ export class DropDownMenuBase extends React.Component<DropDownMenuBaseProps, {}>
         onToggleMenuHandler(showMenu);
 
         if (showMenu) {
-            document.addEventListener('mousedown', this._onOutsideFocusHandler);
-            document.addEventListener('keydown', this._onOutsideFocusHandler);
+            document.addEventListener('mousedown', this._onAnywhereClickHandler);
+            document.addEventListener('keydown', this._keyPressHandler);
         } else {
-            document.removeEventListener('mousedown', this._onOutsideFocusHandler);
-            document.removeEventListener('keydown', this._onOutsideFocusHandler);
+            document.removeEventListener('mousedown', this._onAnywhereClickHandler);
+            document.removeEventListener('keydown', this._keyPressHandler);
         }
     }
 


### PR DESCRIPTION
This is to fix all dropdowns closing on other than chrome browsers, by pressing any key.