### PR TITLE
CS-255 Image file size exceeds warning message

### DIFF
--- a/src/components/__tests__/__snapshots__/image_upload.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/image_upload.test.tsx.snap
@@ -2,36 +2,44 @@
 
 exports[`The image upload component should render 1`] = `
 <div
-  className="image-upload"
+  style={
+    Object {
+      "width": "18rem",
+    }
+  }
 >
   <div
-    style={
-      Object {
-        "height": "18rem",
-        "width": "18rem",
-      }
-    }
+    className="image-upload"
   >
-    <t
-      accept="image/jpeg, image/png"
-      disableClick={false}
-      disabled={false}
-      getDataTransferItems={[Function]}
-      maxSize={Infinity}
-      minSize={0}
-      multiple={false}
-      onBlur={[Function]}
-      onDragEnter={[Function]}
-      onDragLeave={[Function]}
-      onDrop={[Function]}
-      onFocus={[Function]}
-      preventDropOnDocument={true}
-    >
-      <Component />
-    </t>
     <div
-      className="placeholder placeholder--round"
-    />
+      style={
+        Object {
+          "height": "18rem",
+          "width": "18rem",
+        }
+      }
+    >
+      <t
+        accept="image/jpeg, image/png"
+        disableClick={false}
+        disabled={false}
+        getDataTransferItems={[Function]}
+        maxSize={Infinity}
+        minSize={0}
+        multiple={false}
+        onBlur={[Function]}
+        onDragEnter={[Function]}
+        onDragLeave={[Function]}
+        onDrop={[Function]}
+        onFocus={[Function]}
+        preventDropOnDocument={true}
+      >
+        <Component />
+      </t>
+      <div
+        className="placeholder placeholder--round"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/src/components/__tests__/__snapshots__/image_upload.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/image_upload.test.tsx.snap
@@ -2,44 +2,37 @@
 
 exports[`The image upload component should render 1`] = `
 <div
-  style={
-    Object {
-      "width": "18rem",
-    }
-  }
+  className="image-upload"
 >
   <div
-    className="image-upload"
-  >
-    <div
-      style={
-        Object {
-          "height": "18rem",
-          "width": "18rem",
-        }
+    className="image-upload__dropzone"
+    style={
+      Object {
+        "height": "18rem",
+        "width": "18rem",
       }
+    }
+  >
+    <t
+      accept="image/jpeg, image/png"
+      disableClick={false}
+      disabled={false}
+      getDataTransferItems={[Function]}
+      maxSize={Infinity}
+      minSize={0}
+      multiple={false}
+      onBlur={[Function]}
+      onDragEnter={[Function]}
+      onDragLeave={[Function]}
+      onDrop={[Function]}
+      onFocus={[Function]}
+      preventDropOnDocument={true}
     >
-      <t
-        accept="image/jpeg, image/png"
-        disableClick={false}
-        disabled={false}
-        getDataTransferItems={[Function]}
-        maxSize={Infinity}
-        minSize={0}
-        multiple={false}
-        onBlur={[Function]}
-        onDragEnter={[Function]}
-        onDragLeave={[Function]}
-        onDrop={[Function]}
-        onFocus={[Function]}
-        preventDropOnDocument={true}
-      >
-        <Component />
-      </t>
-      <div
-        className="placeholder placeholder--round"
-      />
-    </div>
+      <Component />
+    </t>
+    <div
+      className="placeholder placeholder--round"
+    />
   </div>
 </div>
 `;

--- a/src/components/image_upload.tsx
+++ b/src/components/image_upload.tsx
@@ -194,7 +194,7 @@ export class ImageUpload extends React.Component<ImageUploadProps, ImageUploadSt
         const hoverAreaClasses = classNames('hover-area', { show: dropActive || dropFocus });
 
         return (
-            <div style={{ height: size, width: size }}>
+            <div className="image-upload__dropzone" style={{ height: size, width: size }}>
                 <Dropzone
                     accept="image/jpeg, image/png"
                     multiple={false}
@@ -229,24 +229,24 @@ export class ImageUpload extends React.Component<ImageUploadProps, ImageUploadSt
     }
 
     private _renderFileSizeExceedsMessage(): JSX.Element {
-        const { fileSizeExceedsMessage } = this.props;
+        const { fileSizeExceedsMessage, size } = this.props;
         return (
-            <InputFieldValidation
-                validationError={fileSizeExceedsMessage}
-                labelLayoutWidth="1/1"
-                labelWidthBreakpoint="sm"
-            />
+            <div className="image-upload__warning" style={{ width: size }}>
+                <InputFieldValidation
+                    validationError={fileSizeExceedsMessage}
+                    labelLayoutWidth="1/1"
+                    labelWidthBreakpoint="sm"
+                />
+            </div>
         );
     }
 
     render(): JSX.Element {
-        const { id, size } = this.props;
+        const { id } = this.props;
         const { cropURL, showFileSizeWarning } = this.state;
         return (
-            <div style={{ width: size }}>
-                <div id={id} className="image-upload">
-                    {cropURL ? this._renderCropper() : this._renderDropzone()}
-                </div>
+            <div id={id} className="image-upload">
+                {cropURL ? this._renderCropper() : this._renderDropzone()}
                 {showFileSizeWarning && this._renderFileSizeExceedsMessage()}
             </div>
         );

--- a/src/components/image_upload.tsx
+++ b/src/components/image_upload.tsx
@@ -31,26 +31,15 @@ export interface ImageFile extends File {
 export interface ImageUploadProps {
     /** The ImageUpload list id */
     id?: string;
-    /** Called when an image has been selected */
     onFileSelection?: (file: ImageFile) => any;
-    /** Called when an image has been read */
     onFileRead?: (dataURL: string) => any;
-    /** Size of the image. Include size unit */
     size?: string;
-    /** Shape of the image: 'round' | 'square' */
     shape?: ImageShape;
-    /** Image URL */
     imageURL?: string;
-    /** Placeholder label */
     placeholderLabel?: string;
-    /** Placeholder type: 'person' | 'other' */
     placeholderType?: ImagePlaceholderType;
-    /** The maximum amount of megabytes allowed to be uploaded */
     maxMb?: number;
-    /** The warning message to show when the uploaded image file size exceeds maxMb.
-     * Can be any[] if returned from I18n.format.
-    */
-    fileSizeExceedsMessage?: string | any[];
+    fileSizeExceedsMessage?: string;
     /**
      * Whether cropping should be enabled. If enabled, the user is allowed to choose what
      * part of the image to use. For every change, the `onFileRead` callback is called.
@@ -228,26 +217,22 @@ export class ImageUpload extends React.Component<ImageUploadProps, ImageUploadSt
         );
     }
 
-    private _renderFileSizeExceedsMessage(): JSX.Element {
-        const { fileSizeExceedsMessage, size } = this.props;
-        return (
-            <div className="image-upload__warning" style={{ width: size }}>
-                <InputFieldValidation
-                    validationError={fileSizeExceedsMessage}
-                    labelLayoutWidth="1/1"
-                    labelWidthBreakpoint="sm"
-                />
-            </div>
-        );
-    }
-
     render(): JSX.Element {
-        const { id } = this.props;
+        const { id, size, fileSizeExceedsMessage } = this.props;
         const { cropURL, showFileSizeWarning } = this.state;
         return (
             <div id={id} className="image-upload">
                 {cropURL ? this._renderCropper() : this._renderDropzone()}
-                {showFileSizeWarning && this._renderFileSizeExceedsMessage()}
+                {showFileSizeWarning
+                && (
+                    <div style={{ width: size }}>
+                        <InputFieldValidation
+                            validationError={fileSizeExceedsMessage}
+                            labelLayoutWidth="1/1"
+                            labelWidthBreakpoint="sm"
+                        />
+                    </div>
+                )}
             </div>
         );
     }

--- a/src/components/input_fields/image_upload_field.tsx
+++ b/src/components/input_fields/image_upload_field.tsx
@@ -36,6 +36,11 @@ export interface ImageUploadFieldProps extends InputFieldProps {
     /** The maximum amount of megabytes allowed to be uploaded */
     maxMb?: number;
 
+    /** The warning message to show when the uploaded image file size exceeds maxMb.
+     * Can be any[] if returned from I18n.format.
+    */
+    fileSizeExceedsMessage?: string | any[];
+
     /** Placeholder type: 'person' | 'other' */
     placeholderType?: ImagePlaceholderType;
 }
@@ -98,7 +103,7 @@ export class ImageUploadField extends React.Component
     render() {
         const {
             imageSize, imageShape, placeholder, value, onReadHandler,
-            children, allowCropping, maxMb, placeholderType, ...wrapperProps
+            children, allowCropping, maxMb, placeholderType, fileSizeExceedsMessage, ...wrapperProps
         } = this.props;
         const { id, staticField } = wrapperProps;
         const { touched } = this.state;
@@ -119,6 +124,7 @@ export class ImageUploadField extends React.Component
                                 placeholderLabel={placeholder}
                                 placeholderType={placeholderType}
                                 allowCropping={allowCropping}
+                                fileSizeExceedsMessage={fileSizeExceedsMessage}
                             />
                         )
                 }

--- a/src/components/input_fields/image_upload_field.tsx
+++ b/src/components/input_fields/image_upload_field.tsx
@@ -8,46 +8,20 @@ import { BoxPlaceholder } from '../box_placeholder';
 import { ProfileImage } from '../profile_image';
 
 
-/**
- * The image upload field provides these props in addition to those supported by all input fields.
- */
 export interface ImageUploadFieldProps extends InputFieldProps {
-    /** Size of the image for type image. Include size unit */
     imageSize?: string;
-
-    /** Shape of the image for type image: 'round' | 'square' */
     imageShape?: ImageShape;
-
-    /** Called when the field changes */
     onChangeHandler?: (id: string, value: ImageFile) => any;
-
-    /** Called when an image file is read */
     onReadHandler?: (id: string, dataURL: string) => any;
-
-    /** html placeholder text */
     placeholder?: string;
-
     /** The file URL or preview URL */
     value: string;
-
-    /** Whether cropping should be enabled */
     allowCropping?: boolean;
-
-    /** The maximum amount of megabytes allowed to be uploaded */
     maxMb?: number;
-
-    /** The warning message to show when the uploaded image file size exceeds maxMb.
-     * Can be any[] if returned from I18n.format.
-    */
-    fileSizeExceedsMessage?: string | any[];
-
-    /** Placeholder type: 'person' | 'other' */
+    fileSizeExceedsMessage?: string;
     placeholderType?: ImagePlaceholderType;
 }
 
-/**
- * The image upload field keeps track of whether it has been touched.
- */
 export interface ImageUploadFieldState {
     /** Indicates if the field has been touched (changed) or not from the default value. */
     touched: boolean;

--- a/src/stylesheets/_image_upload.scss
+++ b/src/stylesheets/_image_upload.scss
@@ -3,6 +3,10 @@
     position: relative;
     display: inline-block;
     vertical-align: bottom;
+}
+
+.image-upload__dropzone {
+    position: relative;
 
     .hover-area {
         outline: none;


### PR DESCRIPTION
Issue: `<ImageUploadField />` has a property `maxMb`. Before this PR, when the size of the uploaded image exceeds `maxMb`, it gives no indication for the user what went wrong. Now we add a warning message.

See [CS-255](https://jira.ultimaker.com/browse/CS-255) for more details.

Here is the update for the common component, namely `<ImageUploadField />`.

The preview images below show how the change looks like in the Contributor Portal:
![Screenshot 2019-11-13 at 13 57 26](https://user-images.githubusercontent.com/1527106/68766258-de80f400-061e-11ea-801d-e5f381c817aa.png)

![Screenshot 2019-11-13 at 13 57 53](https://user-images.githubusercontent.com/1527106/68766261-e2147b00-061e-11ea-9fcc-fb2e638fd7b5.png)