### PR TITLE
CS-28 Make cropper zoom out possible

### DIFF
--- a/src/components/__tests__/__snapshots__/image_cropper.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/image_cropper.test.tsx.snap
@@ -41,9 +41,9 @@ exports[`The Image Cropper component should render 1`] = `
   <RangeSlider
     className="image-cropper--slider"
     max={2.5}
-    min={1}
+    min={0.5}
     onChange={[Function]}
-    step={0.1}
+    step={0.05}
     value={1}
   />
   <CloseButton

--- a/src/components/image_cropper.tsx
+++ b/src/components/image_cropper.tsx
@@ -67,9 +67,9 @@ export class ImageCropper extends React.Component<ImageCropperProps, ImageCroppe
     static defaultProps: ImageCropperProps = {
         shape: 'square',
         size: '200px',
-        minScale: 1,
+        minScale: 0.5,
         maxScale: 2.5,
-        scaleStep: 0.1,
+        scaleStep: 0.05,
         borderSize: 25,
         imageURL: null,
         onImageChanged: null,

--- a/src/components/image_upload.tsx
+++ b/src/components/image_upload.tsx
@@ -147,7 +147,10 @@ export class ImageUpload extends React.Component<ImageUploadProps, ImageUploadSt
     }
 
     private _renderCropper(): JSX.Element {
-        const { size, shape, onFileRead, minCropperScale, maxCropperScale, cropperScaleStep } = this.props;
+        const {
+            size, shape, onFileRead,
+            minCropperScale, maxCropperScale, cropperScaleStep,
+        } = this.props;
         const { cropURL } = this.state;
         return (
             <ImageCropper

--- a/src/components/image_upload.tsx
+++ b/src/components/image_upload.tsx
@@ -45,6 +45,9 @@ export interface ImageUploadProps {
      * part of the image to use. For every change, the `onFileRead` callback is called.
      */
     allowCropping?: boolean;
+    minCropperScale?: number;
+    maxCropperScale?: number;
+    cropperScaleStep?: number;
 }
 
 export interface ImageUploadState {
@@ -144,7 +147,7 @@ export class ImageUpload extends React.Component<ImageUploadProps, ImageUploadSt
     }
 
     private _renderCropper(): JSX.Element {
-        const { size, shape, onFileRead } = this.props;
+        const { size, shape, onFileRead, minCropperScale, maxCropperScale, cropperScaleStep } = this.props;
         const { cropURL } = this.state;
         return (
             <ImageCropper
@@ -153,6 +156,9 @@ export class ImageUpload extends React.Component<ImageUploadProps, ImageUploadSt
                 size={size}
                 shape={shape}
                 onCropCancel={this._onCropCancel}
+                minScale={minCropperScale}
+                maxScale={maxCropperScale}
+                scaleStep={cropperScaleStep}
             />
         );
     }

--- a/src/components/input_fields/image_upload_field.tsx
+++ b/src/components/input_fields/image_upload_field.tsx
@@ -17,6 +17,9 @@ export interface ImageUploadFieldProps extends InputFieldProps {
     /** The file URL or preview URL */
     value: string;
     allowCropping?: boolean;
+    minCropperScale?: number;
+    maxCropperScale?: number;
+    cropperScaleStep?: number;
     maxMb?: number;
     fileSizeExceedsMessage?: string;
     placeholderType?: ImagePlaceholderType;
@@ -77,7 +80,8 @@ export class ImageUploadField extends React.Component
     render() {
         const {
             imageSize, imageShape, placeholder, value, onReadHandler,
-            children, allowCropping, maxMb, placeholderType, fileSizeExceedsMessage, ...wrapperProps
+            children, allowCropping, minCropperScale, maxCropperScale, cropperScaleStep,
+            maxMb, placeholderType, fileSizeExceedsMessage, ...wrapperProps
         } = this.props;
         const { id, staticField } = wrapperProps;
         const { touched } = this.state;
@@ -98,6 +102,9 @@ export class ImageUploadField extends React.Component
                                 placeholderLabel={placeholder}
                                 placeholderType={placeholderType}
                                 allowCropping={allowCropping}
+                                minCropperScale={minCropperScale}
+                                maxCropperScale={maxCropperScale}
+                                cropperScaleStep={cropperScaleStep}
                                 fileSizeExceedsMessage={fileSizeExceedsMessage}
                             />
                         )


### PR DESCRIPTION
Now it is possible to zoom out the uploaded images :)
Furthermore, make it possible to adjust the min/max scales, as well as the scale step, via `<ImageUploadField />`.
See CS-28 for details.

Original size:
![Screenshot 2019-12-24 at 11 26 06](https://user-images.githubusercontent.com/1527106/71408950-31978f00-2640-11ea-9b9d-f809c7f7ea46.png)

Scaled:
![Screenshot 2019-12-24 at 11 25 42](https://user-images.githubusercontent.com/1527106/71408956-34927f80-2640-11ea-8bdc-5560fc527e78.png)