### PR TITLE
CS-615: Use a scaled image instead of a full size image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@ultimaker/react-web-components",
-    "version": "5.9.1",
+    "version": "5.9.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2586,6 +2586,15 @@
                 "csstype": "^2.2.0"
             }
         },
+        "@types/react-avatar-editor": {
+            "version": "10.3.5",
+            "resolved": "https://registry.npmjs.org/@types/react-avatar-editor/-/react-avatar-editor-10.3.5.tgz",
+            "integrity": "sha512-MGbqKswSgTjBQ+AexNnqAIe7y+12J+zSBPO9vCHTGMnz+tIWYo444fJ6YqXsfdhutSxSlWX2wgR+xUgpviE78w==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
+            }
+        },
         "@types/react-dom": {
             "version": "16.8.2",
             "resolved": "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "@types/jest": "^23.3.14",
         "@types/lodash.debounce": "^4.0.6",
         "@types/node": "^11.9.3",
+        "@types/react-avatar-editor": "^10.3.5",
         "@types/react-dom": "^16.0.7",
         "@types/react-router": "^4.0.30",
         "@types/react-router-dom": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.9.1",
+    "version": "5.9.2",
     "name": "@ultimaker/react-web-components",
     "description": "Ultimaker's unified react component and style library for front-end web",
     "main": "./dist/index.js",

--- a/src/components/__tests__/image_cropper.test.tsx
+++ b/src/components/__tests__/image_cropper.test.tsx
@@ -1,23 +1,15 @@
 // Copyright (c) 2018 Ultimaker B.V.
 import * as React from 'react';
 import { shallow } from 'enzyme';
-
-// component
+import AvatarEditor from 'react-avatar-editor';
 import RangeSlider from '../range_slider';
 import ImageCropper from '../image_cropper';
-
-let AvatarEditor = require('react-avatar-editor');
-
-if ('default' in AvatarEditor) {
-    /* istanbul ignore next */ // ignores coverage for this line.
-    AvatarEditor = AvatarEditor.default;
-}
 
 describe('The Image Cropper component', () => {
     let props;
     const onImageChanged = jest.fn();
     const onCropCancel = jest.fn();
-    const editor = { getImage: () => ({ toDataURL: () => 'imageData' }) };
+    const mockEditor = { getImageScaledToCanvas: () => ({ toDataURL: () => 'imageData' }) };
 
     beforeEach(() => {
         onImageChanged.mockReset();
@@ -31,7 +23,7 @@ describe('The Image Cropper component', () => {
     const createWrapper = () => {
         const wrapper = shallow(<ImageCropper {...props} />);
         // @ts-ignore
-        wrapper.instance()._editor = editor;
+        wrapper.instance()._editor = mockEditor;
         return wrapper;
     };
 

--- a/src/components/image_cropper.tsx
+++ b/src/components/image_cropper.tsx
@@ -1,19 +1,10 @@
 // Copyright (c) 2018 Ultimaker B.V.
 import * as React from 'react';
-
+import debounce from 'lodash.debounce';
+import AvatarEditor from 'react-avatar-editor';
 import { ImageShape } from './image';
 import RangeSlider from './range_slider';
 import CloseButton from './close_button';
-
-// needs to be imported this way to keep jest happy
-let AvatarEditor = require('react-avatar-editor');
-
-if ('default' in AvatarEditor) {
-    /* istanbul ignore next */ // ignores coverage for this line.
-    AvatarEditor = AvatarEditor.default;
-}
-
-const debounce = require('lodash.debounce');
 
 export interface ImageCropperProps {
     /** Size of the image. Include size unit */
@@ -38,10 +29,10 @@ export interface ImageCropperProps {
     imageURL?: string;
 
     /** Callback for when the image is changed */
-    onImageChanged: (data: string) => any;
+    onImageChanged: (data: string) => void;
 
     /** If given, the user is allowed to cancel cropping. This callback is then called. */
-    onCropCancel?: () => any;
+    onCropCancel?: () => void;
 }
 
 export interface ImageCropperState {
@@ -81,7 +72,7 @@ export class ImageCropper extends React.Component<ImageCropperProps, ImageCroppe
      */
     _onImageChanged = debounce(() => {
         const { onImageChanged } = this.props;
-        const canvas = this._editor.getImage();
+        const canvas = this._editor.getImageScaledToCanvas();
         const imageData = canvas.toDataURL();
         onImageChanged(imageData);
     }, 100);


### PR DESCRIPTION
After cropping, the avatar editor would upload the full-size image even
though these images are used at much smaller dimensions.

This change uses a version of the image scaled down to the size of the
canvas which results in considerable file size reduction for large images.

(I used a different format for commit messages, thoughts?)