### PR TITLE
Remove the border from the ImageCropper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@ultimaker/react-web-components",
-    "version": "5.9.2",
+    "version": "5.9.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.9.2",
+    "version": "5.9.3",
     "name": "@ultimaker/react-web-components",
     "description": "Ultimaker's unified react component and style library for front-end web",
     "main": "./dist/index.js",

--- a/src/components/__tests__/__snapshots__/image_cropper.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/image_cropper.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`The Image Cropper component should render 1`] = `
   className="image-cropper--container"
 >
   <d
-    border={25}
+    border={0}
     borderRadius={0}
     className="editor-canvas"
     color={
@@ -18,7 +18,7 @@ exports[`The Image Cropper component should render 1`] = `
     }
     disableBoundaryChecks={false}
     disableHiDPIScaling={false}
-    height={150}
+    height={200}
     image={null}
     onImageChange={[Function]}
     onImageReady={[Function]}
@@ -36,7 +36,7 @@ exports[`The Image Cropper component should render 1`] = `
     rotate={0}
     scale={1}
     style={Object {}}
-    width={150}
+    width={200}
   />
   <RangeSlider
     className="image-cropper--slider"

--- a/src/components/__tests__/image_cropper.test.tsx
+++ b/src/components/__tests__/image_cropper.test.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import AvatarEditor from 'react-avatar-editor';
 import RangeSlider from '../range_slider';
-import ImageCropper from '../image_cropper';
+import ImageCropper, { ImageCropperProps } from '../image_cropper';
 
 describe('The Image Cropper component', () => {
-    let props;
+    let props: ImageCropperProps;
     const onImageChanged = jest.fn();
     const onCropCancel = jest.fn();
     const mockEditor = { getImageScaledToCanvas: () => ({ toDataURL: () => 'imageData' }) };
@@ -47,7 +47,7 @@ describe('The Image Cropper component', () => {
         }));
     });
 
-    it('should keep the range slider', async () => {
+    it('should keep the range slider', () => {
         const wrapper = createWrapper();
         expect(wrapper.find(RangeSlider).prop('value')).toEqual(1);
         expect(wrapper.find(AvatarEditor).prop('scale')).toEqual(1);
@@ -56,7 +56,7 @@ describe('The Image Cropper component', () => {
         expect(wrapper.find(AvatarEditor).prop('scale')).toEqual(0.5);
     });
 
-    it('should keep the image position', async () => {
+    it('should keep the image position', () => {
         const wrapper = createWrapper();
         const avatarProps: any = wrapper.find(AvatarEditor).props();
         expect(avatarProps.position).toEqual({ x: 0.5, y: 0.5 });
@@ -64,7 +64,7 @@ describe('The Image Cropper component', () => {
         expect(wrapper.find(AvatarEditor).prop('position')).toEqual({ x: 0, y: 1 });
     });
 
-    it('should parse the callback', async () => {
+    it('should parse the callback', () => {
         const wrapper = createWrapper();
         const avatarProps: any = wrapper.find(AvatarEditor).props();
         avatarProps.onImageChange();

--- a/src/components/image_cropper.tsx
+++ b/src/components/image_cropper.tsx
@@ -61,7 +61,7 @@ export class ImageCropper extends React.Component<ImageCropperProps, ImageCroppe
         minScale: 0.5,
         maxScale: 2.5,
         scaleStep: 0.05,
-        borderSize: 25,
+        borderSize: 0,
         imageURL: null,
         onImageChanged: null,
     };


### PR DESCRIPTION
We use avatar images at 180x180 pixels on the profile page of
account.ultimaker.com but we only provide a 130x130px circle when cropping
images. By removing the 25px border that was previously used, we get the
full 180x180px of the cropper tool.

**before**
![image](https://user-images.githubusercontent.com/406439/72437870-f4886d80-37a3-11ea-8074-85b639b6b771.png)
**after**
![image](https://user-images.githubusercontent.com/406439/72437898-079b3d80-37a4-11ea-991c-4389114c06c2.png)
