### PR TITLE
Use new colors for buttons states

### DIFF
--- a/src/stylesheets/_buttons.scss
+++ b/src/stylesheets/_buttons.scss
@@ -85,59 +85,60 @@ button {
 }
 
 .btn--primary {
-    color: $primary-btn-color-text;
+    color: $um-white;
     background-color: $um-blue-5;
 
     &:hover,
     &:focus {
-        background-color: $primary-btn-color-hover;
+        background-color: $um-blue-7;
     }
 
     &:active,
     &.waiting,
     &.waiting:hover {
-        background-color: $primary-btn-color-active;
+        background-color: $um-blue-5;
     }
 
     &.disabled,
     .disabled:hover,
     .disabled:active,
     .disabled:focus {
-        background-color: $primary-btn-color-disabled;
-        color: $primary-btn-color-disabled-text;
+        background-color: $um-gray-5;
     }
 
     .spinner .path {
-        stroke: $primary-btn-color-text;
+        stroke: $um-white;
     }
 }
 
 .btn--secondary {
-    border: 1px solid $secondary-btn-color-border;
+    background-color: $um-white;
+    border: 2px solid;
     padding: 0.8rem 3.5rem 1rem;
-    color: $secondary-btn-color-text;
+    color: $um-blue-5;
 
     &:hover,
     &:focus {
-        background-color: $secondary-btn-color-hover;
+        background-color: $um-gray-3;
     }
 
     &:active,
     &.waiting,
     &.waiting:hover {
-        background-color: $secondary-btn-color-active;
+        background-color: $um-white;
     }
 
     &.disabled,
     &.disabled:hover,
     &.disabled:active,
     .disabled:focus {
-        background-color: $secondary-btn-color-disabled;
-        color: $secondary-btn-color-disabled-text;
+        background-color: $um-white;
+        border-color: $um-gray-5;
+        color: $um-gray-5;
     }
 
     .spinner .path {
-        stroke: $secondary-btn-color-text;
+        stroke: $um-blue-5;
     }
 }
 
@@ -146,13 +147,13 @@ button {
 
     &:hover,
     &:focus {
-        background-color: $quiet-btn-color-hover;
+        background-color: $um-gray-3;
     }
 
     &:active,
     &.waiting,
     &.waiting:hover {
-        background-color: $quiet-btn-color-active;
+        background-color: transparent;
     }
 
     &.disabled,
@@ -160,7 +161,7 @@ button {
     &.disabled:active,
     .disabled:focus {
         background-color: transparent;
-        color: $quiet-btn-color-disabled-text;
+        color: $um-gray-5;
     }
 
     .spinner .path {
@@ -169,32 +170,32 @@ button {
 }
 
 .btn--alert {
-    border: 1px solid $alert-btn-color-border;
+    border: 2px solid $um-red-5;
     padding: 0.8rem 3.5rem 1rem;
-    color: $alert-btn-color-text;
-    background-color: $alert-btn-color;
+    color: $um-red-5;
+    background-color: $um-white;
 
     &:hover,
     &:focus {
-        background-color: $alert-btn-color-hover;
+        background-color: $um-gray-3;
     }
 
     &:active,
     &.waiting,
     &.waiting:hover {
-        background-color: $alert-btn-color-active;
+        background-color: $um-white;
     }
 
     &.disabled,
     .disabled:hover,
     .disabled:active,
     .disabled:focus {
-        background-color: $alert-btn-color-disabled;
-        color: $alert-btn-color-disabled-text;
+        background-color: $um-gray-3;
+        color: $um-white;
     }
 
     .spinner .path {
-        stroke: $alert-btn-color-text;
+        stroke: $um-red-5;
     }
 }
 
@@ -292,8 +293,8 @@ button {
             .btn--circle {
                 width: 4.6rem;
                 height: 4.6rem;
-                background-color: $color-white;
-                color: $color-black;
+                background-color: $um-white;
+                color: $um-black;
             }
         }
     }

--- a/src/stylesheets/_carousel.scss
+++ b/src/stylesheets/_carousel.scss
@@ -3,7 +3,7 @@
 }
 
 .alice-carousel__dots-item {
-    background-color: $primary-btn-color-disabled;
+    background-color: $um-gray-5;
     transition: background-color 0.2s ease-out;
 
     &:hover,

--- a/src/stylesheets/_checkbox.scss
+++ b/src/stylesheets/_checkbox.scss
@@ -15,7 +15,7 @@
     position: relative;
     display: block;
     border-radius: 2px;
-    border: 1px solid $checkbox-color-border;
+    border: 1px solid $um-black;
     transition: background 0.2s ease-out,
         border-color 0.2s ease-out;
 
@@ -33,7 +33,7 @@
     position: absolute;
     top: 0.6rem;
     left: 0.6rem;
-    border: 3px solid $checkbox-color-tick-hover;
+    border: 3px solid $um-gray-5;
     border-top: none;
     border-right: none;
     background: transparent;
@@ -66,7 +66,7 @@
 
     .checkbox__visual::after {
         opacity: 1;
-        border-color: $checkbox-color-tick-active;
+        border-color: $um-white;
     }
 }
 

--- a/src/stylesheets/_icons.scss
+++ b/src/stylesheets/_icons.scss
@@ -22,42 +22,42 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        color: $primary-btn-color-text;
+        color: $um-white;
         background-color: $um-blue-5;
         font-size: 1.6rem;
 
         &.primary {
             svg {
-                fill: $primary-btn-color-text;
+                fill: $um-blue-5;
             }
 
             &.disabled {
-                background-color: $primary-btn-color-disabled;
-                color: $primary-btn-color-disabled-text;
+                background-color: $um-gray-5;
+                color: $um-white;
 
                 svg {
-                    fill: $primary-btn-color-disabled-text;
+                    fill: $um-white;
                 }
             }
         }
 
         &.secondary {
-            color: $secondary-btn-color-text;
-            background-color: $secondary-btn-color;
-            border: 2px solid $secondary-btn-color-border;
+            color: $um-blue-5;
+            background-color: $um-white;
+            border: 2px solid;
 
             svg {
-                fill: $secondary-btn-color-text;
+                fill: $um-blue-5;
             }
         }
 
         &.alert {
-            color: $alert-btn-color-text;
-            background-color: $alert-btn-color;
-            border: 2px solid $alert-btn-color-border;
+            color: $um-red-5;
+            background-color: $um-white;
+            border: 2px solid;
 
             svg {
-                fill: $alert-btn-color-text;
+                fill: $um-red-5;
             }
         }
 

--- a/src/stylesheets/_input_fields.scss
+++ b/src/stylesheets/_input_fields.scss
@@ -264,7 +264,7 @@
     }
 
     input[type='file']:focus + .btn {
-        background-color: $primary-btn-color-hover;
+        background-color: $um-blue-7;
     }
 }
 

--- a/src/stylesheets/_variables.scss
+++ b/src/stylesheets/_variables.scss
@@ -100,32 +100,6 @@ $color-shadow-light: $color-transparent-grey-lighter !default;
 $color-shadow: $color-transparent-grey-dark !default;
 $color-shadow-dark: $color-transparent-grey-darker !default;
 
-$primary-btn-color-text: $color-white !default;
-$primary-btn-color-hover: $color-blue-light !default;
-$primary-btn-color-active: $color-blue-lighter !default;
-$primary-btn-color-disabled: $color-background-darker !default;
-$primary-btn-color-disabled-text: $color-text-lighter !default;
-
-$secondary-btn-color: $color-transparent !default;
-$secondary-btn-color-text: $color-text !default;
-$secondary-btn-color-border: $color-black !default;
-$secondary-btn-color-hover: $color-background-darker !default;
-$secondary-btn-color-active: $color-background-darkest !default;
-$secondary-btn-color-disabled: $color-background-darker !default;
-$secondary-btn-color-disabled-text: $color-text-lighter !default;
-
-$quiet-btn-color-hover: $color-background-darker !default;
-$quiet-btn-color-active: $color-background-darkest !default;
-$quiet-btn-color-disabled-text: $color-text-lighter !default;
-
-$alert-btn-color: $color-transparent !default;
-$alert-btn-color-text: $color-red !default;
-$alert-btn-color-border: $color-red !default;
-$alert-btn-color-hover: $color-background-darker !default;
-$alert-btn-color-active: $color-background-darkest !default;
-$alert-btn-color-disabled: $color-background-darker !default;
-$alert-btn-color-disabled-text: $color-text-lighter !default;
-
 $progress-bar-color-paused: $color-grey-mid !default;
 $progress-bar-color-background: $color-grey-lightest !default;
 
@@ -138,10 +112,6 @@ $context-menu-color-chevron-shadow: $color-transparent-grey-light !default;
 $context-menu-disabled-color-trigger: $color-grey-light !default;
 $context-menu-disabled-color-trigger-hover: $color-background-dark !default;
 $context-menu-disabled-color-hover: $color-transparent !default;
-
-$checkbox-color-tick-active: $color-white !default;
-$checkbox-color-border: $secondary-btn-color-border !default;
-$checkbox-color-tick-hover: $color-border !default;
 
 $tooltip-dark-color-background: $color-grey-darker !default;
 $tooltip-color-text: $color-white !default;


### PR DESCRIPTION
Some of the colors used also touched the checkboxes and the Alice
Carousel component. These have been converted to $um-* colors as well.

This should pave the way for stardust-web buttons to be dropped in as
replacement for the old buttons.