### PR TITLE
Update uuid to v7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3435,6 +3435,14 @@
                 "prop-types": "^15.6.2",
                 "react-inspector": "^2.3.0",
                 "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+                    "dev": true
+                }
             }
         },
         "@storybook/addon-info": {
@@ -16258,6 +16266,12 @@
                         "psl": "^1.1.24",
                         "punycode": "^1.4.1"
                     }
+                },
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+                    "dev": true
                 }
             }
         },
@@ -19003,9 +19017,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.0.tgz",
+            "integrity": "sha512-LNUrNsXdI/fUsypJbWM8Jt4DgQdFAZh41p9C7WE9Cn+CULOEkoG2lgQyH68v3wnIy5K3fN4jdSt270K6IFA3MQ=="
         },
         "v8-compile-cache": {
             "version": "2.1.0",
@@ -19301,6 +19315,14 @@
                     "requires": {
                         "ansi-colors": "^3.0.0",
                         "uuid": "^3.3.2"
+                    },
+                    "dependencies": {
+                        "uuid": {
+                            "version": "3.4.0",
+                            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+                            "dev": true
+                        }
                     }
                 }
             }
@@ -19338,6 +19360,14 @@
                 "log-symbols": "^2.1.0",
                 "loglevelnext": "^1.0.1",
                 "uuid": "^3.1.0"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+                    "dev": true
+                }
             }
         },
         "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "react-spring": "7.2.0",
         "react-tag-autocomplete": "^5.8.0",
         "react-textarea-autosize": "^7.0.4",
-        "uuid": "^3.4.0"
+        "uuid": "^7.0.0"
     },
     "devDependencies": {
         "@babel/core": "^7.8.4",

--- a/src/components/search_bar/__tests__/search_bar.test.tsx
+++ b/src/components/search_bar/__tests__/search_bar.test.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { SearchBar } from '..';
 
-jest.mock('uuid/v4', () => jest.fn().mockReturnValue('d2e08c2a-365b-40a5-9f2d-64c28610b113'));
+jest.mock('uuid', () => ({
+    v4: jest.fn().mockReturnValue('d2e08c2a-365b-40a5-9f2d-64c28610b113'),
+}));
 
 // Use real timers for this one because https://github.com/facebook/jest/issues/3465
 

--- a/src/components/search_bar/search_bar.tsx
+++ b/src/components/search_bar/search_bar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import debounce from 'lodash.debounce';
-import uuidv4 from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 import * as Input from '../input';
 import { Icons } from '../icons';
 


### PR DESCRIPTION
Switch to the [new way](https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-uuid3) of importing and update the corresponding test.

Closes #355 